### PR TITLE
Unit tests for iris_grib.message

### DIFF
--- a/iris_grib/tests/unit/message/__init__.py
+++ b/iris_grib/tests/unit/message/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the :mod:`iris.fileformats.grib.message` package."""
+"""Unit tests for the :mod:`iris_grib.message` package."""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/unit/message/test_GribMessage.py
+++ b/iris_grib/tests/unit/message/test_GribMessage.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the `iris.fileformats.grib.message.GribMessage` class.
+Unit tests for the `iris_grib.message.GribMessage` class.
 
 """
 
@@ -23,9 +23,9 @@ from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
-# Import iris.tests first so that some things can be initialised before
+# Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
-import iris.tests as tests
+import iris_grib.tests as tests
 
 from abc import ABCMeta, abstractmethod
 
@@ -33,16 +33,17 @@ import biggus
 import numpy as np
 
 from iris.exceptions import TranslationError
-from iris.fileformats.grib.message import GribMessage
-from iris.tests import mock
-from iris.tests.unit.fileformats.grib import _make_test_message
+
+from iris_grib.message import GribMessage
+from iris_grib.tests import mock
+from iris_grib.tests.unit import _make_test_message
 
 
 SECTION_6_NO_BITMAP = {'bitMapIndicator': 255, 'bitmap': None}
 
 
 @tests.skip_data
-class Test_messages_from_filename(tests.IrisTest):
+class Test_messages_from_filename(tests.IrisGribTest):
     def test(self):
         filename = tests.get_data_path(('GRIB', '3_layer_viz',
                                         '3_layer.grib2'))
@@ -60,7 +61,7 @@ class Test_messages_from_filename(tests.IrisTest):
         self.assertTrue(my_file.closed)
 
 
-class Test_sections(tests.IrisTest):
+class Test_sections(tests.IrisGribTest):
     def test(self):
         # Check that the `sections` attribute defers to the `sections`
         # attribute on the underlying _RawGribMessage.
@@ -68,7 +69,7 @@ class Test_sections(tests.IrisTest):
         self.assertIs(message.sections, mock.sentinel.SECTIONS)
 
 
-class Test_data__masked(tests.IrisTest):
+class Test_data__masked(tests.IrisGribTest):
     def setUp(self):
         self.bitmap = np.array([0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1])
         self.shape = (3, 4)
@@ -126,7 +127,7 @@ class Test_data__masked(tests.IrisTest):
             message.data.ndarray()
 
 
-class Test_data__unsupported(tests.IrisTest):
+class Test_data__unsupported(tests.IrisGribTest):
     def test_unsupported_grid_definition(self):
         message = _make_test_message({3: {'sourceOfGridDefinition': 1},
                                       6: SECTION_6_NO_BITMAP})
@@ -211,27 +212,32 @@ def _example_section_3(grib_definition_template_number, scanning_mode):
             'Ni': 4}
 
 
-class Test_data__grid_template_0(tests.IrisTest, Mixin_data__grid_template):
+class Test_data__grid_template_0(tests.IrisGribTest,
+                                 Mixin_data__grid_template):
     def section_3(self, scanning_mode):
         return _example_section_3(0, scanning_mode)
 
 
-class Test_data__grid_template_1(tests.IrisTest, Mixin_data__grid_template):
+class Test_data__grid_template_1(tests.IrisGribTest,
+                                 Mixin_data__grid_template):
     def section_3(self, scanning_mode):
         return _example_section_3(1, scanning_mode)
 
 
-class Test_data__grid_template_5(tests.IrisTest, Mixin_data__grid_template):
+class Test_data__grid_template_5(tests.IrisGribTest,
+                                 Mixin_data__grid_template):
     def section_3(self, scanning_mode):
         return _example_section_3(5, scanning_mode)
 
 
-class Test_data__grid_template_12(tests.IrisTest, Mixin_data__grid_template):
+class Test_data__grid_template_12(tests.IrisGribTest,
+                                  Mixin_data__grid_template):
     def section_3(self, scanning_mode):
         return _example_section_3(12, scanning_mode)
 
 
-class Test_data__grid_template_30(tests.IrisTest, Mixin_data__grid_template):
+class Test_data__grid_template_30(tests.IrisGribTest,
+                                  Mixin_data__grid_template):
     def section_3(self, scanning_mode):
         section_3 = _example_section_3(30, scanning_mode)
         # Dimensions are 'Nx' + 'Ny' instead of 'Ni' + 'Nj'.
@@ -242,13 +248,14 @@ class Test_data__grid_template_30(tests.IrisTest, Mixin_data__grid_template):
         return section_3
 
 
-class Test_data__grid_template_40_regular(tests.IrisTest,
+class Test_data__grid_template_40_regular(tests.IrisGribTest,
                                           Mixin_data__grid_template):
     def section_3(self, scanning_mode):
         return _example_section_3(40, scanning_mode)
 
 
-class Test_data__grid_template_90(tests.IrisTest, Mixin_data__grid_template):
+class Test_data__grid_template_90(tests.IrisGribTest,
+                                  Mixin_data__grid_template):
     def section_3(self, scanning_mode):
         section_3 = _example_section_3(90, scanning_mode)
         # Exceptionally, dimensions are 'Nx' + 'Ny' instead of 'Ni' + 'Nj'.
@@ -259,7 +266,7 @@ class Test_data__grid_template_90(tests.IrisTest, Mixin_data__grid_template):
         return section_3
 
 
-class Test_data__unknown_grid_template(tests.IrisTest):
+class Test_data__unknown_grid_template(tests.IrisGribTest):
     def test(self):
         message = _make_test_message(
             {3: _example_section_3(999, 0),

--- a/iris_grib/tests/unit/message/test_Section.py
+++ b/iris_grib/tests/unit/message/test_Section.py
@@ -15,25 +15,25 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for `iris.fileformats.grib.message.Section`.
+Unit tests for `iris_grib.message.Section`.
 
 """
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-# Import iris.tests first so that some things can be initialised before
+# Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
-import iris.tests as tests
+import iris_grib.tests as tests
 
 import gribapi
 import numpy as np
 
-from iris.fileformats.grib.message import Section
+from iris_grib.message import Section
 
 
 @tests.skip_data
-class Test___getitem__(tests.IrisTest):
+class Test___getitem__(tests.IrisGribTest):
     def setUp(self):
         filename = tests.get_data_path(('GRIB', 'uk_t', 'uk_t.grib2'))
         with open(filename, 'rb') as grib_fh:
@@ -66,7 +66,7 @@ class Test___getitem__(tests.IrisTest):
 
 
 @tests.skip_data
-class Test__getitem___pdt_31(tests.IrisTest):
+class Test__getitem___pdt_31(tests.IrisGribTest):
     def setUp(self):
         filename = tests.get_data_path(('GRIB', 'umukv', 'ukv_chan9.grib2'))
         with open(filename, 'rb') as grib_fh:
@@ -84,7 +84,7 @@ class Test__getitem___pdt_31(tests.IrisTest):
 
 
 @tests.skip_data
-class Test_get_computed_key(tests.IrisTest):
+class Test_get_computed_key(tests.IrisGribTest):
     def test_gdt40_computed(self):
         fname = tests.get_data_path(('GRIB', 'gaussian', 'regular_gg.grib2'))
         with open(fname, 'rb') as grib_fh:

--- a/iris_grib/tests/unit/message/test__DataProxy.py
+++ b/iris_grib/tests/unit/message/test__DataProxy.py
@@ -15,25 +15,26 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the `iris.fileformats.grib.message._DataProxy` class.
+Unit tests for the `iris.message._DataProxy` class.
 
 """
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-# Import iris.tests first so that some things can be initialised before
+# Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
-import iris.tests as tests
+import iris_grib.tests as tests
 
 import numpy as np
 from numpy.random import randint
 
 from iris.exceptions import TranslationError
-from iris.fileformats.grib.message import _DataProxy
+
+from iris_grib.message import _DataProxy
 
 
-class Test__bitmap(tests.IrisTest):
+class Test__bitmap(tests.IrisGribTest):
     def test_no_bitmap(self):
         section_6 = {'bitMapIndicator': 255, 'bitmap': None}
         data_proxy = _DataProxy(0, 0, 0, 0)

--- a/iris_grib/tests/unit/message/test__MessageLocation.py
+++ b/iris_grib/tests/unit/message/test__MessageLocation.py
@@ -15,27 +15,26 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the `iris.fileformats.grib.message._MessageLocation` class.
+Unit tests for the `iris.message._MessageLocation` class.
 
 """
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-# Import iris.tests first so that some things can be initialised before
+# Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
-import iris.tests as tests
+import iris_grib.tests as tests
 
-from iris.fileformats.grib.message import _MessageLocation
-from iris.tests import mock
+from iris_grib.message import _MessageLocation
+from iris_grib.tests import mock
 
 
-class Test(tests.IrisTest):
+class Test(tests.IrisGribTest):
     def test(self):
         message_location = _MessageLocation(mock.sentinel.filename,
                                             mock.sentinel.location)
-        patch_target = 'iris.fileformats.grib.message._RawGribMessage.' \
-                       'from_file_offset'
+        patch_target = 'iris_grib.message._RawGribMessage.from_file_offset'
         expected = mock.sentinel.message
         with mock.patch(patch_target, return_value=expected) as rgm:
             result = message_location()

--- a/iris_grib/tests/unit/message/test__RawGribMessage.py
+++ b/iris_grib/tests/unit/message/test__RawGribMessage.py
@@ -15,24 +15,24 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
 """
-Unit tests for the `iris.fileformats.grib.message._RawGribMessage` class.
+Unit tests for the `iris_grib.message._RawGribMessage` class.
 
 """
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-# Import iris.tests first so that some things can be initialised before
+# Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
-import iris.tests as tests
+import iris_grib.tests as tests
 
 import gribapi
 
-from iris.fileformats.grib.message import _RawGribMessage
+from iris_grib.message import _RawGribMessage
 
 
 @tests.skip_data
-class Test(tests.IrisTest):
+class Test(tests.IrisGribTest):
     def setUp(self):
         filename = tests.get_data_path(('GRIB', 'uk_t', 'uk_t.grib2'))
         with open(filename, 'rb') as grib_fh:


### PR DESCRIPTION
Porting `iris.tests.unit.fileformats.grib.message` to `iris_grib`