### PR TITLE
Edition 1 for GribWrapper and load_rules.

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -42,7 +42,7 @@ from . import grib_phenom_translation as itranslation
 from iris.fileformats.rules import ConversionMetadata, Factory, Reference
 from iris.util import _is_circular
 
-from .load_rules import convert as grib1_convert
+from .load_rules import grib1_convert
 from .message import GribMessage
 
 

--- a/iris_grib/load_rules.py
+++ b/iris_grib/load_rules.py
@@ -29,6 +29,7 @@ import numpy as np
 from . import warn_deprecated
 from iris.aux_factory import HybridPressureFactory
 from iris.coords import AuxCoord, CellMethod, DimCoord
+from iris.exceptions import TranslationError
 from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
                                     ReferenceTarget)
 
@@ -50,6 +51,11 @@ def grib1_convert(grib):
         A :class:`iris.fileformats.rules.ConversionMetadata` object.
 
     """
+    if grib.edition != 1:
+        emsg = 'GRIB edition {} is not supported by {!r}.'
+        raise TranslationError(emsg.format(grib.edition,
+                                           type(grib).__name__))
+
     factories = []
     references = []
     standard_name = None

--- a/iris_grib/load_rules.py
+++ b/iris_grib/load_rules.py
@@ -33,9 +33,13 @@ from iris.fileformats.rules import (ConversionMetadata, Factory, Reference,
                                     ReferenceTarget)
 
 
-def convert(grib):
+# Restrict the names imported from this namespace.
+__all__ = ['grib1_convert']
+
+
+def grib1_convert(grib):
     """
-    Converts a GRIB message into the corresponding items of Cube metadata.
+    Converts a GRIB1 message into the corresponding items of Cube metadata.
 
     Args:
 
@@ -55,18 +59,6 @@ def convert(grib):
     cell_methods = []
     dim_coords_and_dims = []
     aux_coords_and_dims = []
-
-    # deprecation warning for this code path for edition 2 messages
-    if grib.edition == 2:
-        msg = ('This GRIB loader is deprecated and will be removed in '
-              'a future release.  Please consider using the new '
-              'GRIB loader by setting the :class:`iris.Future` '
-              'option `strict_grib_load` to True; e.g.:\n'
-              'iris.FUTURE.strict_grib_load = True\n'
-              'Please report issues you experience to:\n'
-              'https://groups.google.com/forum/#!topic/scitools-iris-dev/'
-              'lMsOusKNfaU')
-        warn_deprecated(msg)
 
     if \
             (grib.gridType=="reduced_gg"):
@@ -114,7 +106,6 @@ def convert(grib):
         dim_coords_and_dims.append((DimCoord(grib._x_points, grib._x_coord_name, units="m", coord_system=grib._coord_system), 1))
 
     if \
-            (grib.edition == 1) and \
             (grib.table2Version < 128) and \
             (grib.indicatorOfParameter == 11) and \
             (grib._cf_data is None):
@@ -122,7 +113,6 @@ def convert(grib):
         units = "kelvin"
 
     if \
-            (grib.edition == 1) and \
             (grib.table2Version < 128) and \
             (grib.indicatorOfParameter == 33) and \
             (grib._cf_data is None):
@@ -130,7 +120,6 @@ def convert(grib):
         units = "m s-1"
 
     if \
-            (grib.edition == 1) and \
             (grib.table2Version < 128) and \
             (grib.indicatorOfParameter == 34) and \
             (grib._cf_data is None):
@@ -138,35 +127,24 @@ def convert(grib):
         units = "m s-1"
 
     if \
-            (grib.edition == 1) and \
             (grib._cf_data is not None):
         standard_name = grib._cf_data.standard_name
         long_name = grib._cf_data.standard_name or grib._cf_data.long_name
         units = grib._cf_data.units
 
     if \
-            (grib.edition == 1) and \
             (grib.table2Version >= 128) and \
             (grib._cf_data is None):
         long_name = "UNKNOWN LOCAL PARAM " + str(grib.indicatorOfParameter) + "." + str(grib.table2Version)
         units = "???"
 
     if \
-            (grib.edition == 1) and \
             (grib.table2Version == 1) and \
             (grib.indicatorOfParameter >= 128):
         long_name = "UNKNOWN LOCAL PARAM " + str(grib.indicatorOfParameter) + "." + str(grib.table2Version)
         units = "???"
 
     if \
-            (grib.edition == 2) and \
-            (grib._cf_data is not None):
-        standard_name = grib._cf_data.standard_name
-        long_name = grib._cf_data.long_name
-        units = grib._cf_data.units
-
-    if \
-            (grib.edition == 1) and \
             (grib._phenomenonDateTime != -1.0):
         aux_coords_and_dims.append((DimCoord(points=grib.startStep, standard_name='forecast_period', units=grib._forecastTimeUnit), None))
         aux_coords_and_dims.append((DimCoord(points=grib.phenomenon_points('hours'), standard_name='time', units=Unit('hours since epoch', CALENDAR_GREGORIAN)), None))
@@ -189,166 +167,79 @@ def convert(grib):
             None))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 2):
         add_bounded_time_coords(aux_coords_and_dims, grib)
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 3):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("mean", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 4):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("sum", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 5):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("_difference", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 51):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("mean", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 113):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("mean", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 114):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("sum", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 115):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("mean", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 116):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("sum", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 117):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("mean", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 118):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("_covariance", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 123):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("mean", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 124):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("sum", coords="time"))
 
     if \
-            (grib.edition == 1) and \
             (grib.timeRangeIndicator == 125):
         add_bounded_time_coords(aux_coords_and_dims, grib)
         cell_methods.append(CellMethod("standard_deviation", coords="time"))
 
     if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 0):
-        aux_coords_and_dims.append((DimCoord(points=Unit(grib._forecastTimeUnit).convert(np.int32(grib._forecastTime), "hours"), standard_name='forecast_period', units="hours"), None))
-        aux_coords_and_dims.append((DimCoord(points=grib.phenomenon_points('hours'), standard_name='time', units=Unit('hours since epoch', CALENDAR_GREGORIAN)), None))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber in (8, 9)):
-        add_bounded_time_coords(aux_coords_and_dims, grib)
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 0):
-        cell_methods.append(CellMethod("mean", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 1):
-        cell_methods.append(CellMethod("sum", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 2):
-        cell_methods.append(CellMethod("maximum", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 3):
-        cell_methods.append(CellMethod("minimum", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 4):
-        cell_methods.append(CellMethod("_difference", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 5):
-        cell_methods.append(CellMethod("_root_mean_square", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 6):
-        cell_methods.append(CellMethod("standard_deviation", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 7):
-        cell_methods.append(CellMethod("_convariance", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 8):
-        cell_methods.append(CellMethod("_difference", coords="time"))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 8) and \
-            (grib.typeOfStatisticalProcessing == 9):
-        cell_methods.append(CellMethod("_ratio", coords="time"))
-
-    if \
-            (grib.edition == 1) and \
             (grib.levelType == 'pl'):
         aux_coords_and_dims.append((DimCoord(points=grib.level,  long_name="pressure", units="hPa"), None))
 
     if \
-            (grib.edition == 1) and \
             (grib.levelType == 'sfc'):
 
             if (grib._cf_data is not None) and \
@@ -358,7 +249,6 @@ def convert(grib):
                 aux_coords_and_dims.append((DimCoord(points=grib.level,  long_name="height", units="m", attributes={'positive':'up'}), None))
 
     if \
-            (grib.edition == 1) and \
             (grib.levelType == 'ml') and \
             (hasattr(grib, 'pv')):
         aux_coords_and_dims.append((AuxCoord(grib.level, standard_name='model_level_number', attributes={'positive': 'up'}), None))
@@ -366,65 +256,8 @@ def convert(grib):
         aux_coords_and_dims.append((AuxCoord(grib.pv[grib.numberOfCoordinatesValues//2 + grib.level], long_name='sigma'), None))
         factories.append(Factory(HybridPressureFactory, [{'long_name': 'level_pressure'}, {'long_name': 'sigma'}, Reference('surface_pressure')]))
 
-    if \
-            (grib.edition == 2) and \
-            (grib.typeOfFirstFixedSurface != grib.typeOfSecondFixedSurface):
-        warnings.warn("Different vertical bound types not yet handled.")
-
-    if \
-            (grib.edition == 2) and \
-            (grib.typeOfFirstFixedSurface == 103) and \
-            (grib.typeOfSecondFixedSurface == 255):
-        aux_coords_and_dims.append((DimCoord(points=grib.scaledValueOfFirstFixedSurface/(10.0**grib.scaleFactorOfFirstFixedSurface), standard_name="height", units="m"), None))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.typeOfFirstFixedSurface == 103) and \
-            (grib.typeOfSecondFixedSurface != 255):
-        aux_coords_and_dims.append((DimCoord(points=0.5*(grib.scaledValueOfFirstFixedSurface/(10.0**grib.scaleFactorOfFirstFixedSurface) + grib.scaledValueOfSecondFixedSurface/(10.0**grib.scaleFactorOfSecondFixedSurface)), standard_name="height", units="m", bounds=[grib.scaledValueOfFirstFixedSurface/(10.0**grib.scaleFactorOfFirstFixedSurface), grib.scaledValueOfSecondFixedSurface/(10.0**grib.scaleFactorOfSecondFixedSurface)]), None))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.typeOfFirstFixedSurface == 100) and \
-            (grib.typeOfSecondFixedSurface == 255):
-        aux_coords_and_dims.append((DimCoord(points=grib.scaledValueOfFirstFixedSurface/(10.0**grib.scaleFactorOfFirstFixedSurface), long_name="pressure", units="Pa"), None))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.typeOfFirstFixedSurface == 100) and \
-            (grib.typeOfSecondFixedSurface != 255):
-        aux_coords_and_dims.append((DimCoord(points=0.5*(grib.scaledValueOfFirstFixedSurface/(10.0**grib.scaleFactorOfFirstFixedSurface) + grib.scaledValueOfSecondFixedSurface/(10.0**grib.scaleFactorOfSecondFixedSurface)), long_name="pressure", units="Pa", bounds=[grib.scaledValueOfFirstFixedSurface/(10.0**grib.scaleFactorOfFirstFixedSurface), grib.scaledValueOfSecondFixedSurface/(10.0**grib.scaleFactorOfSecondFixedSurface)]), None))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.typeOfFirstFixedSurface in [105, 119]) and \
-            (grib.numberOfCoordinatesValues > 0):
-        aux_coords_and_dims.append((AuxCoord(grib.scaledValueOfFirstFixedSurface, standard_name='model_level_number', attributes={'positive': 'up'}), None))
-        aux_coords_and_dims.append((DimCoord(grib.pv[grib.scaledValueOfFirstFixedSurface], long_name='level_pressure', units='Pa'), None))
-        aux_coords_and_dims.append((AuxCoord(grib.pv[grib.numberOfCoordinatesValues//2 + grib.scaledValueOfFirstFixedSurface], long_name='sigma'), None))
-        factories.append(Factory(HybridPressureFactory, [{'long_name': 'level_pressure'}, {'long_name': 'sigma'}, Reference('surface_air_pressure')]))
-
     if grib._originatingCentre != 'unknown':
         aux_coords_and_dims.append((AuxCoord(points=grib._originatingCentre, long_name='originating_centre', units='no_unit'), None))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.productDefinitionTemplateNumber == 1):
-        aux_coords_and_dims.append((DimCoord(points=grib.perturbationNumber, long_name='ensemble_member', units='no_unit'), None))
-
-    if \
-            (grib.edition == 2) and \
-            grib.productDefinitionTemplateNumber not in (0, 8):
-        attributes["GRIB_LOAD_WARNING"] = ("unsupported GRIB%d ProductDefinitionTemplate: #4.%d" % (grib.edition, grib.productDefinitionTemplateNumber))
-
-    if \
-            (grib.edition == 2) and \
-            (grib.centre == 'ecmf') and \
-            (grib.discipline == 0) and \
-            (grib.parameterCategory == 3) and \
-            (grib.parameterNumber == 25) and \
-            (grib.typeOfFirstFixedSurface == 105):
-        references.append(ReferenceTarget('surface_air_pressure', lambda cube: {'standard_name': 'surface_air_pressure', 'units': 'Pa', 'data': np.exp(cube.data)}))
 
     return ConversionMetadata(factories, references, standard_name, long_name,
                               units, attributes, cell_methods,

--- a/iris_grib/tests/unit/load_convert/test_convert.py
+++ b/iris_grib/tests/unit/load_convert/test_convert.py
@@ -28,7 +28,7 @@ import mock
 from iris.exceptions import TranslationError
 
 from iris_grib._load_convert import convert
-from iris_grib.tests.unit import _make_test_message, FakeGribMessage
+from iris_grib.tests.unit import _make_test_message
 
 
 class TestGribMessage(tests.IrisGribTest):

--- a/iris_grib/tests/unit/load_rules/test_convert.py
+++ b/iris_grib/tests/unit/load_rules/test_convert.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for :func:`iris_grib.load_rules.convert`."""
+"""Unit tests for :func:`iris_grib.load_rules.grib1_convert`."""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
@@ -31,52 +31,8 @@ import iris
 from iris.fileformats.rules import Reference
 
 from iris_grib import GribWrapper
-from iris_grib.load_rules import convert
-from iris_grib.tests.unit import TestField, TestGribSimple
-
-
-class Test_GribLevels_Mock(TestGribSimple):
-    # Unit test levels with mocking.
-    def test_grib2_height(self):
-        grib = self.mock_grib()
-        grib.edition = 2
-        grib.typeOfFirstFixedSurface = 103
-        grib.scaledValueOfFirstFixedSurface = 12345
-        grib.scaleFactorOfFirstFixedSurface = 0
-        grib.typeOfSecondFixedSurface = 255
-        cube = self.cube_from_message(grib)
-        self.assertEqual(
-            cube.coord('height'),
-            iris.coords.DimCoord(12345, standard_name="height", units="m"))
-
-    def test_grib2_bounded_height(self):
-        grib = self.mock_grib()
-        grib.edition = 2
-        grib.typeOfFirstFixedSurface = 103
-        grib.scaledValueOfFirstFixedSurface = 12345
-        grib.scaleFactorOfFirstFixedSurface = 0
-        grib.typeOfSecondFixedSurface = 103
-        grib.scaledValueOfSecondFixedSurface = 54321
-        grib.scaleFactorOfSecondFixedSurface = 0
-        cube = self.cube_from_message(grib)
-        self.assertEqual(
-            cube.coord('height'),
-            iris.coords.DimCoord(33333, standard_name="height", units="m",
-                                 bounds=[[12345, 54321]]))
-
-    def test_grib2_diff_bound_types(self):
-        grib = self.mock_grib()
-        grib.edition = 2
-        grib.typeOfFirstFixedSurface = 103
-        grib.scaledValueOfFirstFixedSurface = 12345
-        grib.scaleFactorOfFirstFixedSurface = 0
-        grib.typeOfSecondFixedSurface = 102
-        grib.scaledValueOfSecondFixedSurface = 54321
-        grib.scaleFactorOfSecondFixedSurface = 0
-        with mock.patch('warnings.warn') as warn:
-            cube = self.cube_from_message(grib)
-        warn.assert_called_with(
-            "Different vertical bound types not yet handled.")
+from iris_grib.load_rules import grib1_convert
+from iris_grib.tests.unit import TestField
 
 
 class TestBoundedTime(TestField):
@@ -99,10 +55,10 @@ class TestBoundedTime(TestField):
                       'table2Version': 9999}
         attributes.update(kwargs)
         message = mock.Mock(**attributes)
-        self._test_for_coord(message, convert, self.is_forecast_period,
+        self._test_for_coord(message, grib1_convert, self.is_forecast_period,
                              expected_points=[35],
                              expected_bounds=[[15, 55]])
-        self._test_for_coord(message, convert, self.is_time,
+        self._test_for_coord(message, grib1_convert, self.is_time,
                              expected_points=[100],
                              expected_bounds=[[80, 120]])
 
@@ -148,20 +104,12 @@ class TestBoundedTime(TestField):
     def test_time_range_indicator_125(self):
         self.assert_bounded_message(timeRangeIndicator=125)
 
-    def test_product_template_8(self):
-        self.assert_bounded_message(edition=2,
-                                    productDefinitionTemplateNumber=8)
-
-    def test_product_template_9(self):
-        self.assert_bounded_message(edition=2,
-                                    productDefinitionTemplateNumber=9)
-
 
 class Test_GribLevels(tests.IrisTest):
     def test_grib1_hybrid_height(self):
         gm = gribapi.grib_new_from_samples('regular_gg_ml_grib1')
         gw = GribWrapper(gm)
-        results = convert(gw)
+        results = grib1_convert(gw)
 
         factory, = results[0]
         self.assertEqual(factory.factory_class,

--- a/iris_grib/tests/unit/load_rules/test_grib1_convert.py
+++ b/iris_grib/tests/unit/load_rules/test_grib1_convert.py
@@ -28,11 +28,20 @@ import gribapi
 import mock
 
 import iris
+from iris.exceptions import TranslationError
 from iris.fileformats.rules import Reference
 
 from iris_grib import GribWrapper
 from iris_grib.load_rules import grib1_convert
 from iris_grib.tests.unit import TestField
+
+
+class TestBadEdition(tests.IrisGribTest):
+    def test(self):
+        message = mock.Mock(edition=2)
+        emsg = 'GRIB edition 2 is not supported'
+        with self.assertRaisesRegexp(TranslationError, emsg):
+            grib1_convert(message)
 
 
 class TestBoundedTime(TestField):


### PR DESCRIPTION
This PR forces the `GribWrapper` to be `GRIB1` specific, and subsequently purges all `GRIB2` rules from `iris_grib.load_rules.py`