### PR TITLE
Tidy unit test patching.

### DIFF
--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_4_and_5.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_4_and_5.py
@@ -43,11 +43,8 @@ RESOLUTION = 1e6
 
 class Test(tests.IrisGribTest):
     def setUp(self):
-        patch = []
-        patch.append(mock.patch('warnings.warn'))
-        module = 'iris_grib._load_convert'
-        this = '{}._is_circular'.format(module)
-        patch.append(mock.patch(this, return_value=False))
+        self.patch('warnings.warn')
+        self.patch('iris_grib._load_convert._is_circular', return_value=False)
         self.metadata = {'factories': [], 'references': [],
                          'standard_name': None,
                          'long_name': None, 'units': None, 'attributes': {},
@@ -55,9 +52,6 @@ class Test(tests.IrisGribTest):
                          'aux_coords_and_dims': []}
         self.cs = mock.sentinel.coord_system
         self.data = np.arange(10, dtype=np.float64)
-        for p in patch:
-            p.start()
-            self.addCleanup(p.stop)
 
     def _check(self, section, request_warning,
                expect_warning=False, y_dim=0, x_dim=1):

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_5.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_5.py
@@ -36,33 +36,35 @@ from iris_grib._load_convert import grid_definition_template_5
 class Test(tests.IrisGribTest):
     def setUp(self):
         module = 'iris_grib._load_convert'
-        patch = []
+
         self.major = mock.sentinel.major
         self.minor = mock.sentinel.minor
         self.radius = mock.sentinel.radius
-        this = '{}.ellipsoid_geometry'.format(module)
+
+        mfunc = '{}.ellipsoid_geometry'.format(module)
         return_value = (self.major, self.minor, self.radius)
-        patch.append(mock.patch(this, return_value=return_value))
-        this = '{}.ellipsoid'.format(module)
+        self.patch(mfunc, return_value=return_value)
+
+        mfunc = '{}.ellipsoid'.format(module)
         self.ellipsoid = mock.sentinel.ellipsoid
-        patch.append(mock.patch(this, return_value=self.ellipsoid))
-        this = '{}.grid_definition_template_4_and_5'.format(module)
+        self.patch(mfunc, return_value=self.ellipsoid)
+
+        mfunc = '{}.grid_definition_template_4_and_5'.format(module)
         self.coord = mock.sentinel.coord
         self.dim = mock.sentinel.dim
         item = (self.coord, self.dim)
         func = lambda s, m, y, x, c: m['dim_coords_and_dims'].append(item)
-        patch.append(mock.patch(this, side_effect=func))
-        this = 'iris.coord_systems.RotatedGeogCS'
+        self.patch(mfunc, side_effect=func)
+
+        mclass = 'iris.coord_systems.RotatedGeogCS'
         self.cs = mock.sentinel.cs
-        patch.append(mock.patch(this, return_value=self.cs))
+        self.patch(mclass, return_value=self.cs)
+
         self.metadata = {'factories': [], 'references': [],
                          'standard_name': None,
                          'long_name': None, 'units': None, 'attributes': {},
                          'cell_methods': [], 'dim_coords_and_dims': [],
                          'aux_coords_and_dims': []}
-        for p in patch:
-            p.start()
-            self.addCleanup(p.stop)
 
     def test(self):
         metadata = deepcopy(self.metadata)

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
@@ -38,9 +38,7 @@ from iris_grib._load_convert import product_definition_template_31
 
 class Test(tests.IrisGribTest):
     def setUp(self):
-        patch = mock.patch('warnings.warn')
-        patch.start()
-        self.addCleanup(patch.stop)
+        self.patch('warnings.warn')
         self.metadata = {'factories': [], 'references': [],
                          'standard_name': None,
                          'long_name': None, 'units': None, 'attributes': None,


### PR DESCRIPTION
Use the `iris_grib.tests.IrisGribTest.patch` convenience method.