### PR TITLE
entries for hybrid height and hybrid pressure added to grib save rules

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -665,6 +665,16 @@ def set_fixed_surfaces(cube, grib):
         output_unit = cf_units.Unit('K')
         v_coord = cube.coord("air_potential_temperature")
 
+    elif cube.coords("level_height"):
+        grib_v_code = 118
+        output_unit = None
+        v_coord = cube.coord("level_height")
+
+    elif cube.coords("model_level_number"):
+        grib_v_code = 119
+        output_unit = None
+        v_coord = cube.coord("model_level_number")
+
     # unknown / absent
     else:
         # check for *ANY* height coords at all...

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -665,11 +665,6 @@ def set_fixed_surfaces(cube, grib):
         output_unit = cf_units.Unit('K')
         v_coord = cube.coord("air_potential_temperature")
 
-    elif cube.coords("level_height"):
-        grib_v_code = 118
-        output_unit = None
-        v_coord = cube.coord("level_height")
-
     elif cube.coords("model_level_number"):
         grib_v_code = 119
         output_unit = None


### PR DESCRIPTION
@marqh 
I am not entirely sure that I am doing what is intended here, but this was my best guess.

This is from a support ticket (https://exxconfigmgmt:6391/browse/EPM-1336) in which hybrid heights were stopping cubes from saving in the iris-grib saver.

Having spent some time on this ticket previously, I know that the problem was in the limited number of vertical coordinates that the grib saver recognized, so (with a few extra notes on the ticket supplied by Mark) I have just added two vertical hybrid coordinates.

The codes for these are correct; that I know.  What I am unsure of is whether the coordinate names (level_height and model_level_number) are correct, and whether anything else needs also be added or changed.