### PR TITLE
Remove use of threads.local as a means of storing options.

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -23,10 +23,10 @@ cube metadata.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
+from argparse import Namespace
 from collections import namedtuple, Iterable, OrderedDict
 from datetime import datetime, timedelta
 import math
-import threading
 import warnings
 
 import cartopy.crs as ccrs
@@ -49,9 +49,9 @@ from .message import GribMessage
 # Restrict the names imported from this namespace.
 __all__ = ['convert']
 
-options = threading.local()
-options.warn_on_unsupported = False
-options.support_hindcast_values = True
+
+options = Namespace(warn_on_unsupported=False,
+                    support_hindcast_values=True)
 
 ScanningMode = namedtuple('ScanningMode', ['i_negative',
                                            'j_positive',


### PR DESCRIPTION
Closes #71.
This is the least intrusive change I can come up with that addresses the problem of threads.local usage. ``threads.local`` in itself is not a bad thing - it just needs to be initialised appropriately. That would be a more significant change here (and would require some care to avoid treading on settings that a user wishes to override, not to mention the performance cost). 