### PR TITLE
Add support for Lambert Conformal saving

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -527,15 +527,15 @@ def grid_definition_template_30(cube, grib):
     first_x = first_x % 360
     central_lon = cs.central_lon % 360
 
-    gribapi.grib_set_long(grib, "latitudeOfFirstGridPoint",
-                          int(first_y * 1e6))
-    gribapi.grib_set_long(grib, "longitudeOfFirstGridPoint",
-                          int(first_x * 1e6))
-    gribapi.grib_set_long(grib, "LaD", cs.central_lat * 1e6)
-    gribapi.grib_set_long(grib, "LoV", central_lon * 1e6)
+    gribapi.grib_set(grib, "latitudeOfFirstGridPoint",
+                     int(np.round(first_y * 1e6)))
+    gribapi.grib_set(grib, "longitudeOfFirstGridPoint",
+                     int(np.round(first_x * 1e6)))
+    gribapi.grib_set(grib, "LaD", cs.central_lat * 1e6)
+    gribapi.grib_set(grib, "LoV", central_lon * 1e6)
     latin1, latin2 = cs.secant_latitudes
-    gribapi.grib_set_long(grib, "Latin1", latin1 * 1e6)
-    gribapi.grib_set_long(grib, "Latin2", latin2 * 1e6)
+    gribapi.grib_set(grib, "Latin1", latin1 * 1e6)
+    gribapi.grib_set(grib, "Latin2", latin2 * 1e6)
     gribapi.grib_set(grib, 'resolutionAndComponentFlags',
                      0x1 << _RESOLUTION_AND_COMPONENTS_GRID_WINDS_BIT)
 
@@ -543,9 +543,9 @@ def grid_definition_template_30(cube, grib):
     # that the cone converges.
     poliest_sec = latin1 if abs(latin1) > abs(latin2) else latin2
     centre_flag = 0x0 if poliest_sec > 0 else 0x1
-    gribapi.grib_set_long(grib, 'projectionCentreFlag', centre_flag)
-    gribapi.grib_set_long(grib, "latitudeOfSouthernPole", 0)
-    gribapi.grib_set_long(grib, "longitudeOfSouthernPole", 0)
+    gribapi.grib_set(grib, 'projectionCentreFlag', centre_flag)
+    gribapi.grib_set(grib, "latitudeOfSouthernPole", 0)
+    gribapi.grib_set(grib, "longitudeOfSouthernPole", 0)
 
 
 def grid_definition_section(cube, grib):

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -31,10 +31,12 @@ import cf_units
 import gribapi
 import numpy as np
 import numpy.ma as ma
+import cartopy.crs as ccrs
 
 import iris
 import iris.exceptions
-from iris.coord_systems import GeogCS, RotatedGeogCS, TransverseMercator
+from iris.coord_systems import (GeogCS, RotatedGeogCS, TransverseMercator,
+                                LambertConformal)
 from . import grib_phenom_translation as gptx
 from ._load_convert import (_STATISTIC_TYPE_NAMES, _TIME_RANGE_UNITS)
 from iris.util import is_regular, regular_step
@@ -221,9 +223,9 @@ def shape_of_the_earth(cube, grib):
                               ellipsoid.semi_minor_axis)
 
 
-def grid_dims(x_coord, y_coord, grib):
-    gribapi.grib_set_long(grib, "Ni", x_coord.shape[0])
-    gribapi.grib_set_long(grib, "Nj", y_coord.shape[0])
+def grid_dims(x_coord, y_coord, grib, x_str, y_str):
+    gribapi.grib_set_long(grib, x_str, x_coord.shape[0])
+    gribapi.grib_set_long(grib, y_str, y_coord.shape[0])
 
 
 def latlon_first_last(x_coord, y_coord, grib):
@@ -264,12 +266,13 @@ def scanning_mode_flags(x_coord, y_coord, grib):
                           int(y_coord.points[1] - y_coord.points[0] > 0))
 
 
-def horizontal_grid_common(cube, grib):
+def horizontal_grid_common(cube, grib, xy=False):
+    nx_str, ny_str = ("Nx", "Ny") if xy else ("Ni", "Nj")
     # Grib encoding of the sequences of X and Y points.
     y_coord = cube.coord(dimensions=[0])
     x_coord = cube.coord(dimensions=[1])
     shape_of_the_earth(cube, grib)
-    grid_dims(x_coord, y_coord, grib)
+    grid_dims(x_coord, y_coord, grib, nx_str, ny_str)
     scanning_mode_flags(x_coord, y_coord, grib)
 
 
@@ -327,6 +330,20 @@ def rotated_pole(cube, grib):
     gribapi.grib_set(grib, "latitudeOfSouthernPole", - int(round(latitude)))
     gribapi.grib_set(grib, "longitudeOfSouthernPole", int(round(longitude)))
     gribapi.grib_set(grib, "angleOfRotation", 0)
+
+
+def points_in_unit(coord, unit):
+    points = coord.units.convert(coord.points, unit)
+    points = np.around(points).astype(int)
+    return points
+
+
+def step(points, atol):
+    diffs = points[1:] - points[:-1]
+    mean_diff = np.mean(diffs).astype(points.dtype)
+    if not np.allclose(diffs, mean_diff, atol=atol):
+        raise ValueError()
+    return int(mean_diff)
 
 
 def grid_definition_template_0(cube, grib):
@@ -411,29 +428,23 @@ def grid_definition_template_12(cube, grib):
 
     # Normalise the coordinate values to centimetres - the resolution
     # used in the GRIB message.
-    def points_in_cm(coord):
-        points = coord.units.convert(coord.points, 'cm')
-        points = np.around(points).astype(int)
-        return points
-    y_cm = points_in_cm(y_coord)
-    x_cm = points_in_cm(x_coord)
+    y_cm = points_in_unit(y_coord, 'cm')
+    x_cm = points_in_unit(x_coord, 'cm')
 
     # Set some keys specific to GDT12.
     # Encode the horizontal points.
 
     # NB. Since we're already in centimetres, our tolerance for
     # discrepancy in the differences is 1.
-    def step(points):
-        diffs = points[1:] - points[:-1]
-        mean_diff = np.mean(diffs).astype(points.dtype)
-        if not np.allclose(diffs, mean_diff, atol=1):
-            msg = ('Irregular coordinates not supported for transverse '
-                   'Mercator.')
-            raise iris.exceptions.TranslationError(msg)
-        return int(mean_diff)
-
-    gribapi.grib_set(grib, 'Di', abs(step(x_cm)))
-    gribapi.grib_set(grib, 'Dj', abs(step(y_cm)))
+    try:
+        x_step = step(x_cm, atol=1)
+        y_step = step(y_cm, atol=1)
+    except ValueError:
+        msg = ('Irregular coordinates not supported for transverse '
+               'Mercator.')
+        raise iris.exceptions.TranslationError(msg)
+    gribapi.grib_set(grib, 'Di', abs(x_step))
+    gribapi.grib_set(grib, 'Dj', abs(y_step))
     horizontal_grid_common(cube, grib)
 
     # GRIBAPI expects unsigned ints in X1, X2, Y1, Y2 but it should accept
@@ -470,6 +481,73 @@ def grid_definition_template_12(cube, grib):
     gribapi.grib_set(grib, "scaleFactorAtReferencePoint", value)
 
 
+def grid_definition_template_30(cube, grib):
+    """
+    Set keys within the provided grib message based on
+    Grid Definition Template 3.30.
+
+    Template 3.30 is used to represent a Lambert Conformal grid.
+
+    """
+
+    gribapi.grib_set(grib, "gridDefinitionTemplateNumber", 30)
+
+    # Retrieve some information from the cube.
+    y_coord = cube.coord(dimensions=[0])
+    x_coord = cube.coord(dimensions=[1])
+    cs = y_coord.coord_system
+
+    # Normalise the coordinate values to millimetres - the resolution
+    # used in the GRIB message.
+    y_mm = points_in_unit(y_coord, 'mm')
+    x_mm = points_in_unit(x_coord, 'mm')
+
+    # Encode the horizontal points.
+
+    # NB. Since we're already in millimetres, our tolerance for
+    # discrepancy in the differences is 1.
+    try:
+        x_step = step(x_mm, atol=1)
+        y_step = step(y_mm, atol=1)
+    except ValueError:
+        msg = ('Irregular coordinates not supported for Lambert '
+               'Conformal.')
+        raise iris.exceptions.TranslationError(msg)
+    gribapi.grib_set(grib, 'Dx', abs(x_step))
+    gribapi.grib_set(grib, 'Dy', abs(y_step))
+
+    horizontal_grid_common(cube, grib, xy=True)
+
+    # Transform first point into geographic CS
+    geog = cs.ellipsoid if cs.ellipsoid is not None else GeogCS(1)
+    first_x, first_y = geog.as_cartopy_crs().transform_point(
+        x_coord.points[0],
+        y_coord.points[0],
+        cs.as_cartopy_crs())
+    first_x = first_x % 360
+    central_lon = cs.central_lon % 360
+
+    gribapi.grib_set_long(grib, "latitudeOfFirstGridPoint",
+                          int(first_y * 1e6))
+    gribapi.grib_set_long(grib, "longitudeOfFirstGridPoint",
+                          int(first_x * 1e6))
+    gribapi.grib_set_long(grib, "LaD", cs.central_lat * 1e6)
+    gribapi.grib_set_long(grib, "LoV", central_lon * 1e6)
+    latin1, latin2 = cs.secant_latitudes
+    gribapi.grib_set_long(grib, "Latin1", latin1 * 1e6)
+    gribapi.grib_set_long(grib, "Latin2", latin2 * 1e6)
+    gribapi.grib_set(grib, 'resolutionAndComponentFlags',
+                     0x1 << _RESOLUTION_AND_COMPONENTS_GRID_WINDS_BIT)
+
+    # Which pole are the parallels closest to? That is the direction
+    # that the cone converges.
+    poliest_sec = latin1 if abs(latin1) > abs(latin2) else latin2
+    centre_flag = 0x0 if poliest_sec > 0 else 0x1
+    gribapi.grib_set_long(grib, 'projectionCentreFlag', centre_flag)
+    gribapi.grib_set_long(grib, "latitudeOfSouthernPole", 0)
+    gribapi.grib_set_long(grib, "longitudeOfSouthernPole", 0)
+
+
 def grid_definition_section(cube, grib):
     """
     Set keys within the grid definition section of the provided grib message,
@@ -501,6 +579,9 @@ def grid_definition_section(cube, grib):
         # Transverse Mercator coordinate system (template 3.12).
         grid_definition_template_12(cube, grib)
 
+    elif isinstance(cs, LambertConformal):
+        # Lambert Conformal coordinate system (template 3.30).
+        grid_definition_template_30(cube, grib)
     else:
         raise ValueError('Grib saving is not supported for coordinate system: '
                          '{}'.format(cs))

--- a/iris_grib/tests/__init__.py
+++ b/iris_grib/tests/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -31,7 +31,12 @@ import inspect
 import os
 import os.path
 
-from iris.tests import IrisTest, main, skip_data, get_data_path
+try:
+    from iris.tests import IrisTest_nometa as IrisTest
+except ImportError:
+    from iris.tests import IrisTest
+
+from iris.tests import main, skip_data, get_data_path
 
 
 #: Basepath for iris-grib test results.

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_section.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_section.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -26,7 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # importing anything else.
 import iris_grib.tests as tests
 
-from iris.coord_systems import LambertConformal
+from iris.coord_systems import Orthographic
 from iris.exceptions import TranslationError
 
 from iris_grib._save_rules import grid_definition_section
@@ -46,7 +46,7 @@ class Test(tests.IrisGribTest, GdtTestMixin):
             grid_definition_section(test_cube, self.mock_grib)
 
     def test__fail_unsupported_coord_system(self):
-        cs = LambertConformal()
+        cs = Orthographic(0, 0)
         test_cube = self._make_test_cube(cs=cs)
         with self.assertRaisesRegexp(
                 ValueError,

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_30.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_30.py
@@ -1,0 +1,138 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of iris-grib.
+#
+# iris-grib is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-grib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_30`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris_grib.tests first so that some things can be initialised before
+# importing anything else.
+import iris_grib.tests as tests
+
+import numpy as np
+
+import iris.coords
+from iris.coord_systems import GeogCS, LambertConformal
+from iris.exceptions import TranslationError
+
+from iris_grib._save_rules import grid_definition_template_30
+from iris_grib.tests.unit.save_rules import GdtTestMixin
+
+
+class FakeGribError(Exception):
+    pass
+
+
+class Test(tests.IrisGribTest, GdtTestMixin):
+    def setUp(self):
+        self.default_ellipsoid = GeogCS(semi_major_axis=6377563.396,
+                                        semi_minor_axis=6356256.909)
+        self.test_cube = self._make_test_cube()
+
+        GdtTestMixin.setUp(self)
+
+    def _make_test_cube(self, cs=None, x_points=None, y_points=None):
+        # Create a cube with given properties, or minimal defaults.
+        if cs is None:
+            cs = self._default_coord_system()
+        if x_points is None:
+            x_points = self._default_x_points()
+        if y_points is None:
+            y_points = self._default_y_points()
+
+        x_coord = iris.coords.DimCoord(x_points, 'projection_x_coordinate',
+                                       units='m', coord_system=cs)
+        y_coord = iris.coords.DimCoord(y_points, 'projection_y_coordinate',
+                                       units='m', coord_system=cs)
+        test_cube = iris.cube.Cube(np.zeros((len(y_points), len(x_points))))
+        test_cube.add_dim_coord(y_coord, 0)
+        test_cube.add_dim_coord(x_coord, 1)
+        return test_cube
+
+    def _default_coord_system(self):
+        return LambertConformal(central_lat=39.0, central_lon=-96.0,
+                                false_easting=0.0, false_northing=0.0,
+                                secant_latitudes=(33, 45),
+                                ellipsoid=self.default_ellipsoid)
+
+    def test__template_number(self):
+        grid_definition_template_30(self.test_cube, self.mock_grib)
+        self._check_key('gridDefinitionTemplateNumber', 30)
+
+    def test__shape_of_earth(self):
+        grid_definition_template_30(self.test_cube, self.mock_grib)
+        self._check_key('shapeOfTheEarth', 7)
+        self._check_key('scaleFactorOfEarthMajorAxis', 0)
+        self._check_key('scaledValueOfEarthMajorAxis', 6377563.396)
+        self._check_key('scaleFactorOfEarthMinorAxis', 0)
+        self._check_key('scaledValueOfEarthMinorAxis', 6356256.909)
+
+    def test__grid_shape(self):
+        test_cube = self._make_test_cube(x_points=np.arange(13),
+                                         y_points=np.arange(6))
+        grid_definition_template_30(test_cube, self.mock_grib)
+        self._check_key('Nx', 13)
+        self._check_key('Ny', 6)
+
+    def test__grid_points(self):
+        test_cube = self._make_test_cube(x_points=[1e6, 3e6, 5e6, 7e6],
+                                         y_points=[4e6, 9e6])
+        grid_definition_template_30(test_cube, self.mock_grib)
+        self._check_key("latitudeOfFirstGridPoint", 71676530)
+        self._check_key("longitudeOfFirstGridPoint", 287218188)
+        self._check_key("Dx", 2e9)
+        self._check_key("Dy", 5e9)
+
+    def test__template_specifics(self):
+        grid_definition_template_30(self.test_cube, self.mock_grib)
+        self._check_key("LaD", 39e6)
+        self._check_key("LoV", 264e6)
+        self._check_key("Latin1", 33e6)
+        self._check_key("Latin2", 45e6)
+        self._check_key("latitudeOfSouthernPole", 0)
+        self._check_key("longitudeOfSouthernPole", 0)
+
+    def test__scanmode(self):
+        grid_definition_template_30(self.test_cube, self.mock_grib)
+        self._check_key('iScansPositively', 1)
+        self._check_key('jScansPositively', 1)
+
+    def test__scanmode_reverse(self):
+        test_cube = self._make_test_cube(x_points=np.arange(7e6, 0, -1e6))
+        grid_definition_template_30(test_cube, self.mock_grib)
+        self._check_key('iScansPositively', 0)
+        self._check_key('jScansPositively', 1)
+
+    def test_projection_centre(self):
+        grid_definition_template_30(self.test_cube, self.mock_grib)
+        self._check_key("projectionCentreFlag", 0)
+
+    def test_projection_centre_south_pole(self):
+        cs = LambertConformal(central_lat=39.0, central_lon=-96.0,
+                              false_easting=0.0, false_northing=0.0,
+                              secant_latitudes=(-33, -45),
+                              ellipsoid=self.default_ellipsoid)
+        test_cube = self._make_test_cube(cs=cs)
+        grid_definition_template_30(test_cube, self.mock_grib)
+        self._check_key("projectionCentreFlag", 1)
+
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
No tests yet, will add them shortly.

False eastings/northings are not supported for Lambert Conformal in GRIB, so they are ignored on save. Doing this doesn't lose any information about the locations of the points though, since GRIB stores the longitude and latitude of the first point in the grid.