### PR TITLE
Prevent usage of floats as indices to numpy arrays due to deprecation

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -184,7 +184,7 @@ class GribWrapper(object):
             # The byte offset requires to be reset back to the first byte
             # of this message. The file pointer offset is always at the end
             # of the current message due to the grib-api reading the message.
-            proxy = GribDataProxy(shape, np.zeros(.0).dtype, np.nan,
+            proxy = GribDataProxy(shape, np.zeros(0).dtype, np.nan,
                                   grib_fh.name,
                                   offset - message_length)
             self._data = biggus.NumpyArrayAdapter(proxy)

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -1351,7 +1351,7 @@ def hybrid_factories(section, metadata):
                              units='Pa')
             metadata['aux_coords_and_dims'].append((coord, None))
             # Create the sigma scalar coordinate.
-            offset += NV / 2
+            offset += NV // 2
             coord = AuxCoord(pv[offset], long_name='sigma')
             metadata['aux_coords_and_dims'].append((coord, None))
             # Create the associated factory reference.


### PR DESCRIPTION
Newer versions of numpy don't allow floats to be used as indices to arrays, even if they are integer-valued. This PR makes the tests pass (plus iris integration tests) with newer version of numpy, but I have not assessed other places in the code which may cause errors but are not caught by tests.