### PR TITLE
Allow dynamically supporting individual templates

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -2105,35 +2105,14 @@ def product_definition_section(section, metadata, discipline, tablesVersion,
     # Reference GRIB2 Code Table 4.0.
     template = section['productDefinitionTemplateNumber']
 
-    probability = None
-    if template == 0:
-        # Process analysis or forecast at a horizontal level or
-        # in a horizontal layer at a point in time.
-        product_definition_template_0(section, metadata, rt_coord)
-    elif template == 1:
-        # Process individual ensemble forecast, control and perturbed, at
-        # a horizontal level or in a horizontal layer at a point in time.
-        product_definition_template_1(section, metadata, rt_coord)
-    elif template == 8:
-        # Process statistically processed values at a horizontal level or in a
-        # horizontal layer in a continuous or non-continuous time interval.
-        product_definition_template_8(section, metadata, rt_coord)
-    elif template == 9:
-        probability = \
-            product_definition_template_9(section, metadata, rt_coord)
-    elif template == 10:
-        product_definition_template_10(section, metadata, rt_coord)
-    elif template == 11:
-        product_definition_template_11(section, metadata, rt_coord)
-    elif template == 31:
-        # Process satellite product.
-        product_definition_template_31(section, metadata, rt_coord)
-    elif template == 40:
-        product_definition_template_40(section, metadata, rt_coord)
-    else:
+    try:
+        handler = ProductDefinitionTemplateHandlers[template]
+    except KeyError:
         msg = 'Product definition template [{}] is not ' \
             'supported'.format(template)
         raise TranslationError(msg)
+
+    probability = handler(section, metadata, rt_coord)
 
     # Translate GRIB2 phenomenon to CF phenomenon.
     if tablesVersion != _CODE_TABLES_MISSING:
@@ -2293,3 +2272,12 @@ def convert(field):
         result = grib1_convert(field)
 
     return result
+
+ProductDefinitionTemplateHandlers = {0: product_definition_template_0,
+                                     1: product_definition_template_1,
+                                     8: product_definition_template_8,
+                                     9: product_definition_template_9,
+                                     10: product_definition_template_10,
+                                     11: product_definition_template_11,
+                                     31: product_definition_template_31,
+                                     40: product_definition_template_40}


### PR DESCRIPTION
In the current implementation, adding support for a particular Product or Grid Definition Template requires a release of the library. It would be nice to be able to add support for a template at runtime. This is not possible with an `iris.load()` callback because the load fails before the callback is even reached.

This PR demonstrates how the code could be changed to allow adding a function to handle a particular template at runtime. Currently it still requires accessing a private module.

```
import iris
from iris_grib._load_convert import ProductDefinitionTemplateHandlers

def my_handler(section, metadata, rt_coord):
    ...

ProductDefinitionTemplateHandlers[32] = my_handler

# Load a file which uses Product Definition Template 32
iris.load('myfile.grib2')
```

