### PR TITLE
Version to 1.10.1 for release.

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -47,7 +47,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.10.0-dev'
+__version__ = '0.10.1'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']


### PR DESCRIPTION
Reported version string was not right when "1.10.0" was tagged.
So with this change I'm aiming to move on and define a "1.10.1" instead.

As usual, when merged, I'll then tag "1.10.1" and create another PR moving version string to "1.11.0-dev".

@marqh I think we have also not been bothering with version branches here, e.g. in this case "1.10.x" ??