### PR TITLE
Amended version string to form 'major.minor+1.0-DEV'.

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -47,7 +47,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.11.x'
+__version__ = '0.11.0-DEV'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']


### PR DESCRIPTION
My previous change #80  was a goof !
the ".x" form is suitable for branch naming, and **_not_** a reported version string.