### PR TITLE
Port the changes from iris.fileformats.grib back into iris_grib.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 sudo: false
 env:
   - python=2.7
-    iris=v1.10.0
-
-  - python=2.7
     iris=master
 
 install:

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 channels:
     - scitools
 dependencies:
-    - iris=1.*
+    - iris=2.*
     - ecmwf_grib=1.14

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -414,7 +414,7 @@ def ellipsoid(shapeOfTheEarth, major, minor, radius):
 
     """
     # Supported shapeOfTheEarth values.
-    if shapeOfTheEarth not in (0, 1, 3, 6, 7):
+    if shapeOfTheEarth not in (0, 1, 2, 3, 4, 5, 6, 7):
         msg = 'Grid definition section 3 contains an unsupported ' \
             'shape of the earth [{}]'.format(shapeOfTheEarth)
         raise TranslationError(msg)
@@ -425,25 +425,36 @@ def ellipsoid(shapeOfTheEarth, major, minor, radius):
     elif shapeOfTheEarth == 1:
         # Earth assumed spherical with radius specified (in m) by
         # data producer.
-        if radius is ma.masked:
+        if ma.is_masked(radius):
             msg = 'Ellipsoid for shape of the earth {} requires a' \
                 'radius to be specified.'.format(shapeOfTheEarth)
             raise ValueError(msg)
         result = icoord_systems.GeogCS(radius)
+    elif shapeOfTheEarth == 2:
+        # Earth assumed oblate spheroid with size as determined by IAU in 1965.
+        result = icoord_systems.GeogCS(6378160, inverse_flattening=297.0)
     elif shapeOfTheEarth in [3, 7]:
         # Earth assumed oblate spheroid with major and minor axes
         # specified (in km)/(in m) by data producer.
         emsg_oblate = 'Ellipsoid for shape of the earth [{}] requires a' \
             'semi-{} axis to be specified.'
-        if major is ma.masked:
+        if ma.is_masked(major):
             raise ValueError(emsg_oblate.format(shapeOfTheEarth, 'major'))
-        if minor is ma.masked:
+        if ma.is_masked(minor):
             raise ValueError(emsg_oblate.format(shapeOfTheEarth, 'minor'))
         # Check whether to convert from km to m.
         if shapeOfTheEarth == 3:
             major *= 1000
             minor *= 1000
         result = icoord_systems.GeogCS(major, minor)
+    elif shapeOfTheEarth == 4:
+        # Earth assumed oblate spheroid as defined in IAG-GRS80 model.
+        result = icoord_systems.GeogCS(6378137,
+                                       inverse_flattening=298.257222101)
+    elif shapeOfTheEarth == 5:
+        # Earth assumed represented by WGS84 (as used by ICAO since 1998).
+        result = icoord_systems.GeogCS(6378137,
+                                       inverse_flattening=298.257223563)
     elif shapeOfTheEarth == 6:
         # Earth assumed spherical with radius of 6 371 229.0m
         result = icoord_systems.GeogCS(6371229)

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -1156,22 +1156,18 @@ def product_definition_section(cube, grib):
 
 def data_section(cube, grib):
     # Masked data?
-    if isinstance(cube.data, ma.core.MaskedArray):
-        # What missing value shall we use?
-        if not np.isnan(cube.data.fill_value):
-            # Use the data's fill value.
-            fill_value = float(cube.data.fill_value)
-        else:
-            # We can't use the data's fill value if it's NaN,
+    if ma.isMaskedArray(cube.data):
+        fill_value = cube.fill_value
+        if fill_value is None or np.isnan(cube.fill_value):
+            # We can't use the cube's fill value if it's NaN,
             # the GRIB API doesn't like it.
             # Calculate an MDI outside the data range.
             min, max = cube.data.min(), cube.data.max()
             fill_value = min - (max - min) * 0.1
-        # Prepare the unmaksed data array, using fill_value as the MDI.
-        data = cube.data.filled(fill_value)
     else:
         fill_value = None
-        data = cube.data
+
+    data = cube.data
 
     # units scaling
     grib2_info = gptx.cf_phenom_to_grib2_info(cube.standard_name,

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -26,10 +26,11 @@ import six
 from collections import namedtuple
 import re
 
-import biggus
 import gribapi
 import numpy as np
+import numpy.ma as ma
 
+from iris._lazy_data import array_masked_to_nans, as_lazy_data
 from iris.exceptions import TranslationError
 
 
@@ -88,7 +89,7 @@ class GribMessage(object):
         """
         # A RawGribMessage giving gribapi access to the original grib message.
         self._raw_message = raw_message
-        # A _MessageLocation which biggus uses to read the message data array,
+        # A _MessageLocation which dask uses to read the message data array,
         # by which time this message may be dead and the original grib file
         # closed.
         self._recreate_raw = recreate_raw
@@ -114,9 +115,22 @@ class GribMessage(object):
         return self._raw_message.sections
 
     @property
+    def bmdi(self):
+        # Not sure of any cases where GRIB provides a fill value.
+        # Default for fill value is None.
+        return None
+
+    @property
+    def realised_dtype(self):
+        return np.dtype('f8')
+
+    def core_data(self):
+        return self.data
+
+    @property
     def data(self):
         """
-        The data array from the GRIB message as a biggus Array.
+        The data array from the GRIB message as a dask Array.
 
         The shape of the array will match the logical shape of the
         message's grid. For example, a simple global grid would be
@@ -150,9 +164,9 @@ class GribMessage(object):
                 shape = (grid_section['numberOfDataPoints'],)
             else:
                 shape = (grid_section['Nj'], grid_section['Ni'])
-            proxy = _DataProxy(shape, np.dtype('f8'), np.nan,
+            proxy = _DataProxy(shape, self.realised_dtype, np.nan,
                                self._recreate_raw)
-            data = biggus.NumpyArrayAdapter(proxy)
+            data = as_lazy_data(proxy)
         else:
             fmt = 'Grid definition template {} is not supported'
             raise TranslationError(fmt.format(template))
@@ -180,12 +194,13 @@ class _MessageLocation(namedtuple('_MessageLocation', 'filename offset')):
 class _DataProxy(object):
     """A reference to the data payload of a single GRIB message."""
 
-    __slots__ = ('shape', 'dtype', 'fill_value', 'recreate_raw')
+    __slots__ = ('shape', 'dtype', 'recreate_raw')
 
     def __init__(self, shape, dtype, fill_value, recreate_raw):
+        # TODO: I (@pelson) have no idea why fill_value remains an argument as
+        # it isn't used. It was copied verbatim from iris' dask branch.
         self.shape = shape
         self.dtype = dtype
-        self.fill_value = fill_value
         self.recreate_raw = recreate_raw
 
     @property
@@ -245,20 +260,21 @@ class _DataProxy(object):
                 # Only the non-masked values are included in codedValues.
                 _data = np.empty(shape=bitmap.shape)
                 _data[bitmap.astype(bool)] = data
-                # `np.ma.masked_array` masks where input = 1, the opposite of
-                # the behaviour specified by the GRIB spec.
-                data = np.ma.masked_array(_data, mask=np.logical_not(bitmap))
+                # Use nan where input = 1, the opposite of the behaviour
+                # specified by the GRIB spec.
+                _data[np.logical_not(bitmap.astype(bool))] = np.nan
+                data = _data
             else:
                 msg = 'Shapes of data and bitmap do not match.'
                 raise TranslationError(msg)
 
         data = data.reshape(self.shape)
+
         return data.__getitem__(keys)
 
     def __repr__(self):
         msg = '<{self.__class__.__name__} shape={self.shape} ' \
-            'dtype={self.dtype!r} fill_value={self.fill_value!r} ' \
-            'recreate_raw={self.recreate_raw!r} '
+            'dtype={self.dtype!r} recreate_raw={self.recreate_raw!r} '
         return msg.format(self=self)
 
     def __getstate__(self):

--- a/iris_grib/tests/results/unit/load_cubes/load_cubes/reduced_raw.cml
+++ b/iris_grib/tests/results/unit/load_cubes/load_cubes/reduced_raw.cml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <cubes xmlns="urn:x-iris:cubeml-0.2">
-  <cube standard_name="geopotential" units="m2 s-2">
+  <cube core-dtype="float64" dtype="float64" standard_name="geopotential" units="m2 s-2">
     <attributes>
       <attribute name="centre" value="European Centre for Medium Range Weather Forecasts"/>
     </attributes>

--- a/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
+++ b/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -61,7 +61,9 @@ class TestBoundedTime(TestField):
                       '_forecastTimeUnit': 'hours',
                       'phenomenon_bounds': lambda u: (80, 120),
                       '_phenomenonDateTime': -1,
-                      'table2Version': 9999}
+                      'table2Version': 9999,
+                      '_originatingCentre': 'xxx',
+                      }
         attributes.update(kwargs)
         message = mock.Mock(**attributes)
         self._test_for_coord(message, grib1_convert, self.is_forecast_period,

--- a/iris_grib/tests/unit/load_convert/test_ellipsoid.py
+++ b/iris_grib/tests/unit/load_convert/test_ellipsoid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -42,7 +42,7 @@ MDI = ma.masked
 
 class Test(tests.IrisGribTest):
     def test_shape_unsupported(self):
-        unsupported = [2, 4, 5, 8, 9, 10, MDI]
+        unsupported = [8, 9, 10, MDI]
         emsg = 'unsupported shape of the earth'
         for shape in unsupported:
             with self.assertRaisesRegexp(TranslationError, emsg):

--- a/iris_grib/tests/unit/message/test_GribMessage.py
+++ b/iris_grib/tests/unit/message/test_GribMessage.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -29,10 +29,11 @@ import iris_grib.tests as tests
 
 from abc import ABCMeta, abstractmethod
 
-import biggus
 import mock
 import numpy as np
+import numpy.ma as ma
 
+from iris._lazy_data import as_concrete_data, is_lazy_data
 from iris.exceptions import TranslationError
 
 from iris_grib.message import GribMessage
@@ -86,23 +87,45 @@ class Test_data__masked(tests.IrisGribTest):
         message = _make_test_message({3: self._section_3,
                                       6: SECTION_6_NO_BITMAP,
                                       7: {'codedValues': values}})
-        result = message.data.ndarray()
+        result = as_concrete_data(message.data)
         expected = values.reshape(self.shape)
         self.assertEqual(result.shape, self.shape)
         self.assertArrayEqual(result, expected)
 
-    def test_bitmap_present(self):
+    def test_bitmap_present_int_data(self):
         # Test the behaviour where bitmap and codedValues shapes
-        # are not equal.
+        # are not equal, and codedValues is integer data.
+        data_type = np.int64
         input_values = np.arange(5)
-        output_values = np.array([-1, -1, 0, 1, -1, -1, -1, 2, -1, 3, -1, 4])
+        output_values = np.array([-1, -1, 0, 1, -1, -1, -1, 2, -1, 3, -1, 4],
+                                 dtype=data_type)
         message = _make_test_message({3: self._section_3,
                                       6: {'bitMapIndicator': 0,
                                           'bitmap': self.bitmap},
                                       7: {'codedValues': input_values}})
-        result = message.data.masked_array()
-        expected = np.ma.masked_array(output_values,
-                                      np.logical_not(self.bitmap))
+        result = as_concrete_data(message.data, nans_replacement=ma.masked,
+                                  result_dtype=data_type)
+        expected = ma.masked_array(output_values,
+                                   np.logical_not(self.bitmap))
+        expected = expected.reshape(self.shape)
+        self.assertMaskedArrayEqual(result, expected)
+        self.assertEqual(result.dtype, data_type)
+
+    def test_bitmap_present_float_data(self):
+        # Test the behaviour where bitmap and codedValues shapes
+        # are not equal, and codedValues is float data.
+        data_type = np.float32
+        input_values = np.arange(5, dtype=np.float32) + 5
+        output_values = np.array([-1, -1, 5, 6, -1, -1, -1, 7, -1, 8, -1, 9],
+                                 dtype=data_type)
+        message = _make_test_message({3: self._section_3,
+                                      6: {'bitMapIndicator': 0,
+                                          'bitmap': self.bitmap},
+                                      7: {'codedValues': input_values}})
+        result = as_concrete_data(message.data, nans_replacement=ma.masked,
+                                  result_dtype=data_type)
+        expected = ma.masked_array(output_values,
+                                   np.logical_not(self.bitmap))
         expected = expected.reshape(self.shape)
         self.assertMaskedArrayEqual(result, expected)
 
@@ -115,7 +138,7 @@ class Test_data__masked(tests.IrisGribTest):
                                           'bitmap': self.bitmap},
                                       7: {'codedValues': values}})
         with self.assertRaisesRegexp(TranslationError, 'do not match'):
-            message.data.masked_array()
+            as_concrete_data(message.data)
 
     def test_bitmap__invalid_indicator(self):
         values = np.arange(12)
@@ -124,7 +147,7 @@ class Test_data__masked(tests.IrisGribTest):
                                           'bitmap': None},
                                       7: {'codedValues': values}})
         with self.assertRaisesRegexp(TranslationError, 'unsupported bitmap'):
-            message.data.ndarray()
+            as_concrete_data(message.data)
 
 
 class Test_data__unsupported(tests.IrisGribTest):
@@ -183,11 +206,11 @@ class Mixin_data__grid_template(six.with_metaclass(ABCMeta, object)):
              6: SECTION_6_NO_BITMAP,
              7: {'codedValues': np.arange(12)}})
         data = message.data
-        self.assertIsInstance(data, biggus.Array)
+        self.assertTrue(is_lazy_data(data))
         self.assertEqual(data.shape, (3, 4))
         self.assertEqual(data.dtype, np.floating)
-        self.assertIs(data.fill_value, np.nan)
-        self.assertArrayEqual(data.ndarray(), np.arange(12).reshape(3, 4))
+        self.assertArrayEqual(as_concrete_data(data),
+                              np.arange(12).reshape(3, 4))
 
     def test_regular_mode_0(self):
         self._test(0)

--- a/iris_grib/tests/unit/save_rules/test_data_section.py
+++ b/iris_grib/tests/unit/save_rules/test_data_section.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -94,8 +94,8 @@ class TestMDI(tests.IrisGribTest):
 
     def test_masked_with_finite_fill_value(self):
         cube = iris.cube.Cube(np.ma.MaskedArray([1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
-                                                mask=[0, 0, 0, 1, 1, 1],
-                                                fill_value=2000))
+                                                mask=[0, 0, 0, 1, 1, 1]),
+                              fill_value=2000)
         grib_message = mock.sentinel.GRIB_MESSAGE
         with mock.patch(GRIB_API) as grib_api:
             data_section(cube, grib_message)
@@ -107,8 +107,8 @@ class TestMDI(tests.IrisGribTest):
 
     def test_masked_with_nan_fill_value(self):
         cube = iris.cube.Cube(np.ma.MaskedArray([1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
-                                                mask=[0, 0, 0, 1, 1, 1],
-                                                fill_value=np.nan))
+                                                mask=[0, 0, 0, 1, 1, 1]),
+                              fill_value=np.nan)
         grib_message = mock.sentinel.GRIB_MESSAGE
         with mock.patch(GRIB_API) as grib_api:
             data_section(cube, grib_message)
@@ -135,8 +135,8 @@ class TestMDI(tests.IrisGribTest):
         # When re-scaling masked data with a finite fill value, ensure
         # the fill value and any filled values are also re-scaled.
         cube = iris.cube.Cube(np.ma.MaskedArray([1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
-                                                mask=[0, 0, 0, 1, 1, 1],
-                                                fill_value=2000),
+                                                mask=[0, 0, 0, 1, 1, 1]),
+                              fill_value=2000,
                               standard_name='geopotential_height', units='km')
         grib_message = mock.sentinel.GRIB_MESSAGE
         with mock.patch(GRIB_API) as grib_api:
@@ -152,8 +152,8 @@ class TestMDI(tests.IrisGribTest):
         # a fill value is chosen which allows for the scaling, and any
         # filled values match the chosen fill value.
         cube = iris.cube.Cube(np.ma.MaskedArray([-1.0, 2.0, -1.0, 2.0],
-                                                mask=[0, 0, 1, 1],
-                                                fill_value=np.nan),
+                                                mask=[0, 0, 1, 1]),
+                              fill_value=np.nan,
                               standard_name='geopotential_height', units='km')
         grib_message = mock.sentinel.GRIB_MESSAGE
         with mock.patch(GRIB_API) as grib_api:

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.5',
     ],
     install_requires = [
-        'iris>=1.9,<2',
+        #        'iris>=1.9,<2',
         # Also: the ECMWF GRIB API
     ],
     extras_require = {


### PR DESCRIPTION
I've done this with very little understanding of the original rationale for integrating iris_grib back into iris, so I may have missed a key detail.