### PR TITLE
Fix for backwards-incompatible change in iris.fileformats.rules.Loader

### DIFF
--- a/iris_grib/tests/unit/test_load_cubes.py
+++ b/iris_grib/tests/unit/test_load_cubes.py
@@ -41,7 +41,7 @@ class Test(tests.IrisGribTest):
             rules_load.return_value = expected_result
             result = load_cubes(files, callback)
             kwargs = {}
-            loader = Loader(generator, kwargs, converter, None)
+            loader = Loader(generator, kwargs, converter)
             rules_load.assert_called_once_with(files, callback, loader)
             self.assertIs(result, expected_result)
 


### PR DESCRIPTION
Simple fix, just to prove recent merge is o.k.

It may not be worth much to merge this, as https://github.com/SciTools/iris/tree/dask_mask_array is coming soon ...