### PR TITLE
Version string for v.0.12.0

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -47,7 +47,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.12.0-DEV'
+__version__ = '0.12.0'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']


### PR DESCRIPTION
Let's cut v0.12.0, to release the changeover to eccodes.
When we're agreed to this, I'll cut a release from it
( and then re-bump the version string of course... )