### PR TITLE
Test against latest conda-forge iris.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
   # Install iris-grib's dependencies
   # --------------------------------
-  - conda install --quiet --yes python=${python} iris ecmwf_grib;
+  - conda install --quiet --yes python=${python} iris ecmwf_grib numpy=1.13 cartopy=0.15 mock filelock pep8;
   - conda list
 
   # Download iris-test-data

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,12 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set show_channel_urls True
-  - conda config --add channels scitools
+  - conda config --add channels conda-forge
   - conda config --add channels defaults
 
   # Install iris-grib's dependencies
   # --------------------------------
-  - wget https://github.com/scitools/iris/archive/${iris}.tar.gz -O iris.tar.gz;
-  - if [ ${iris:0:1} == "v" ]; then
-       iris="${iris:1:${#iris}-1}";
-    fi
-  - tar xzf iris.tar.gz && rm -rf iris.tar.gz && mv iris-${iris} iris_source;
-  - conda install --quiet --yes python=${python} --file=./iris_source/minimal-conda-requirements.txt;
-  - conda install --quiet --yes ecmwf_grib;
-  - pip install ./iris_source --no-deps;
-  - rm -rf iris_source;
+  - conda install --quiet --yes python=${python} iris ecmwf_grib;
   - conda list
 
   # Download iris-test-data


### PR DESCRIPTION
**WIP**
Test have been failing since it tests against iris-master, but was also relying on "iris/minimal-conda-requirements.txt", which is now defunct.
We "ought" to be testing against the latest Iris release, not master, in any case.
I think this was not doing so as it predated our first usable Iris 2 release.

Hopefully we now have a usable Iris v2 on conda-forge, so we should now test against that.
