### PR TITLE
Add a release-notes section.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,6 +91,29 @@ using ``iris-grib``::
     >>> iris.save(my_cube, 'my_file.grib2')
 
 
+Getting Started
+===============
+
+To ensure all ``iris-grib`` dependencies, it is sufficient to have installed
+:mod:`Iris <iris>` itself.
+
+The simplest way to install is with
+`conda <https://conda.io/miniconda.html>`_ ,
+using the `conda-forge channel <https://anaconda.org/conda-forge>`_ ,
+with the command
+
+    $ conda install iris-grib -c conda-forge
+
+Development sources are hosted at `<https://github.com/SciTools/iris-grib>`_ .
+
+Releases
+--------
+
+The latest release is v0.12.x .
+
+For recent changes, see `Release Notes <ref/release_notes.html>`_ .
+
+
 Indices and tables
 ==================
 

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -1,0 +1,54 @@
+What's new in Iris-grib v0.13
+=============================
+
+:Release: 0.13.0
+:Date: T.B.D.
+
+Features
+--------
+
+* Added loading for data on Hybrid Height levels (surface type 118 in
+  code table 4.5).
+
+Bug Fixes
+---------
+
+* Fixed a bug with loading data on Hybrid Pressure levels (surface types 105
+  and 119 in code table 4.5).  
+  Previously, *all* hybrid coordinate values, in both 'level_pressure' and
+  'sigma' coordinates, were loaded from the next level up,
+  i.e. (model_level_number + 1).
+
+  .. note::
+
+      This changes loading behaviour : previous results were simply wrong.
+
+
+What's new in Iris-grib v0.12
+=============================
+
+:Release: 0.12
+:Date: 25 Oct 2017
+
+Use `ecCodes <https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home>`_ for
+the file interface.
+This is ECMWF's replacement for the older GRIB-API, which is now deprecated.
+
+
+What's new in Iris-grib v0.11
+=============================
+
+:Release: 0.11
+:Date: 25 Oct 2017
+
+Update for Iris v2.0+, using Dask instead of Biggus
+
+
+What's new in Iris-grib v0.9
+=============================
+
+:Release: 0.9.0
+:Date: 25 Jul 2016
+
+Stable release of iris_grib to support iris v1.10
+


### PR DESCRIPTION
I'm feeling the need for this, since #106 is a bugfix with behaviour change.

Coming up soon : 
  * further fix to Hybrid Pressure loading to get an actual factory
  * saving for both hybrid height and hybrid pressure

... so I think change notes will be useful