### PR TITLE
Test against latest conda-forge iris

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 env:
   - python=2.7
-    iris=master
 
 install:
   # Fetch and install conda
@@ -17,7 +16,7 @@ install:
 
   # Install iris-grib's dependencies
   # --------------------------------
-  - conda install --quiet --yes python=${python} iris ecmwf_grib numpy=1.13 cartopy=0.15 mock filelock pep8;
+  - conda install --quiet --yes python=${python} iris ecmwf_grib numpy cartopy mock filelock pep8;
   - conda list
 
   # Download iris-test-data


### PR DESCRIPTION
This PR updates the .travis.yml to pick up the latest iris (v2.1) from conda-forge by making the following changes:
- unpin the version of numpy
- unpin the version of cartopy
- remove an unnecessary `iris=master` statement