### PR TITLE
Save Mercator Grid Definition Template

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -523,7 +523,7 @@ def grid_definition_template_12(cube, grib):
         x_step = step(x_cm, atol=1)
         y_step = step(y_cm, atol=1)
     except ValueError:
-        msg = ('Irregular coordinates not supported for transverse '
+        msg = ('Irregular coordinates not supported for Transverse '
                'Mercator.')
         raise iris.exceptions.TranslationError(msg)
     gribapi.grib_set(grib, 'Di', abs(x_step))
@@ -611,14 +611,14 @@ def grid_definition_template_30(cube, grib):
     central_lon = cs.central_lon % 360
 
     gribapi.grib_set(grib, "latitudeOfFirstGridPoint",
-                     int(np.round(first_y * 1e6)))
+                     int(np.round(first_y / _DEFAULT_DEGREES_UNITS)))
     gribapi.grib_set(grib, "longitudeOfFirstGridPoint",
-                     int(np.round(first_x * 1e6)))
-    gribapi.grib_set(grib, "LaD", cs.central_lat * 1e6)
-    gribapi.grib_set(grib, "LoV", central_lon * 1e6)
+                     int(np.round(first_x / _DEFAULT_DEGREES_UNITS)))
+    gribapi.grib_set(grib, "LaD", cs.central_lat / _DEFAULT_DEGREES_UNITS)
+    gribapi.grib_set(grib, "LoV", central_lon / _DEFAULT_DEGREES_UNITS)
     latin1, latin2 = cs.secant_latitudes
-    gribapi.grib_set(grib, "Latin1", latin1 * 1e6)
-    gribapi.grib_set(grib, "Latin2", latin2 * 1e6)
+    gribapi.grib_set(grib, "Latin1", latin1 / _DEFAULT_DEGREES_UNITS)
+    gribapi.grib_set(grib, "Latin2", latin2 / _DEFAULT_DEGREES_UNITS)
     gribapi.grib_set(grib, 'resolutionAndComponentFlags',
                      0x1 << _RESOLUTION_AND_COMPONENTS_GRID_WINDS_BIT)
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -35,8 +35,8 @@ import cartopy.crs as ccrs
 
 import iris
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
-from iris.coord_systems import (GeogCS, RotatedGeogCS, TransverseMercator,
-                                LambertConformal, Mercator)
+from iris.coord_systems import (GeogCS, RotatedGeogCS, Mercator,
+                                TransverseMercator, LambertConformal)
 import iris.exceptions
 
 from . import grib_phenom_translation as gptx
@@ -214,6 +214,10 @@ def shape_of_the_earth(cube, grib):
         gribapi.grib_set_long(grib, "scaleFactorOfRadiusOfSphericalEarth", 0)
         gribapi.grib_set_long(grib, "scaledValueOfRadiusOfSphericalEarth",
                               ellipsoid.semi_major_axis)
+        gribapi.grib_set_long(grib, "scaleFactorOfEarthMajorAxis", 0)
+        gribapi.grib_set_long(grib, "scaledValueOfEarthMajorAxis", 0)
+        gribapi.grib_set_long(grib, "scaleFactorOfEarthMinorAxis", 0)
+        gribapi.grib_set_long(grib, "scaledValueOfEarthMinorAxis", 0)
     # Oblate spheroid earth.
     else:
         gribapi.grib_set_long(grib, "shapeOfTheEarth", 7)
@@ -462,7 +466,7 @@ def grid_definition_template_10(cube, grib):
 
     horizontal_grid_common(cube, grib)
 
-    # Transform first and last points into geographic CS
+    # Transform first and last points into geographic CS.
     geog = cs.ellipsoid if cs.ellipsoid is not None else GeogCS(1)
     first_x, first_y, = geog.as_cartopy_crs().transform_point(
         x_coord.points[0],
@@ -484,8 +488,7 @@ def grid_definition_template_10(cube, grib):
     gribapi.grib_set(grib, "longitudeOfLastGridPoint",
                      int(np.round(last_x / _DEFAULT_DEGREES_UNITS)))
 
-    # Encode the latitude at which the projection intersects the Earth
-    # should this be cs.central_lat or cs.standard parallel?
+    # Encode the latitude at which the projection intersects the Earth.
     gribapi.grib_set(grib, 'LaD',
                      cs.standard_parallel / _DEFAULT_DEGREES_UNITS)
 

--- a/iris_grib/tests/unit/save_rules/__init__.py
+++ b/iris_grib/tests/unit/save_rules/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2018, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -26,7 +26,9 @@ import iris_grib.tests as tests
 import mock
 import numpy as np
 
-import iris
+from iris.coords import DimCoord
+from iris.coord_systems import GeogCS
+from iris.cube import Cube
 from iris.fileformats.pp import EARTH_RADIUS as PP_DEFAULT_EARTH_RADIUS
 
 
@@ -57,7 +59,7 @@ class GdtTestMixin(object):
         self.test_cube = self._make_test_cube()
 
     def _default_coord_system(self):
-        return iris.coord_systems.GeogCS(PP_DEFAULT_EARTH_RADIUS)
+        return GeogCS(PP_DEFAULT_EARTH_RADIUS)
 
     def _default_x_points(self):
         # Define simple, regular coordinate points.
@@ -66,7 +68,8 @@ class GdtTestMixin(object):
     def _default_y_points(self):
         return [7.0, 8.0]  # N.B. is_regular will *fail* on length-1 coords.
 
-    def _make_test_cube(self, cs=None, x_points=None, y_points=None):
+    def _make_test_cube(self, cs=None, x_points=None, y_points=None,
+                        coord_units='degrees'):
         # Create a cube with given properties, or minimal defaults.
         if cs is None:
             cs = self._default_coord_system()
@@ -75,13 +78,11 @@ class GdtTestMixin(object):
         if y_points is None:
             y_points = self._default_y_points()
 
-        x_coord = iris.coords.DimCoord(x_points, standard_name='longitude',
-                                       units='degrees',
-                                       coord_system=cs)
-        y_coord = iris.coords.DimCoord(y_points, standard_name='latitude',
-                                       units='degrees',
-                                       coord_system=cs)
-        test_cube = iris.cube.Cube(np.zeros((len(y_points), len(x_points))))
+        x_coord = DimCoord(x_points, long_name='longitude',
+                           units=coord_units, coord_system=cs)
+        y_coord = DimCoord(y_points, long_name='latitude',
+                           units=coord_units, coord_system=cs)
+        test_cube = Cube(np.zeros((len(y_points), len(x_points))))
         test_cube.add_dim_coord(y_coord, 0)
         test_cube.add_dim_coord(x_coord, 1)
         return test_cube

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_10.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_10.py
@@ -1,0 +1,122 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of iris-grib.
+#
+# iris-grib is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-grib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_10`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris_grib.tests first so that some things can be initialised before
+# importing anything else.
+import iris_grib.tests as tests
+
+import numpy as np
+
+import iris.coords
+from iris.coord_systems import GeogCS, Mercator
+from iris.exceptions import TranslationError
+
+from iris_grib._save_rules import grid_definition_template_10
+from iris_grib.tests.unit.save_rules import GdtTestMixin
+
+
+class FakeGribError(Exception):
+    pass
+
+
+class Test(tests.IrisGribTest, GdtTestMixin):
+    def setUp(self):
+        self.default_ellipsoid = GeogCS(semi_major_axis=6371200.0)
+        self.test_cube = self._make_test_cube()
+
+        GdtTestMixin.setUp(self)
+
+    def _make_test_cube(self, cs=None, x_points=None, y_points=None):
+        # Create a cube with given properties, or minimal defaults.
+        if cs is None:
+            cs = self._default_coord_system()
+        if x_points is None:
+            x_points = self._default_x_points()
+        if y_points is None:
+            y_points = self._default_y_points()
+
+        x_coord = iris.coords.DimCoord(x_points, 'projection_x_coordinate',
+                                       units='m', coord_system=cs)
+        y_coord = iris.coords.DimCoord(y_points, 'projection_y_coordinate',
+                                       units='m', coord_system=cs)
+        test_cube = iris.cube.Cube(np.zeros((len(y_points), len(x_points))))
+        test_cube.add_dim_coord(y_coord, 0)
+        test_cube.add_dim_coord(x_coord, 1)
+        return test_cube
+
+    def _default_coord_system(self):
+        return Mercator(standard_parallel=14.,
+                        ellipsoid=self.default_ellipsoid)
+
+    def test__template_number(self):
+        grid_definition_template_10(self.test_cube, self.mock_grib)
+        self._check_key('gridDefinitionTemplateNumber', 10)
+
+    def test__shape_of_earth(self):
+        grid_definition_template_10(self.test_cube, self.mock_grib)
+        self._check_key('shapeOfTheEarth', 1)
+        self._check_key('scaleFactorOfRadiusOfSphericalEarth', 0)
+        self._check_key('scaleFactorOfEarthMajorAxis', 0)
+        self._check_key('scaledValueOfEarthMajorAxis', 0)
+        self._check_key('scaleFactorOfEarthMinorAxis', 0)
+        self._check_key('scaledValueOfEarthMinorAxis', 0)
+
+    def test__grid_shape(self):
+        test_cube = self._make_test_cube(x_points=np.arange(13),
+                                         y_points=np.arange(6))
+        grid_definition_template_10(test_cube, self.mock_grib)
+        self._check_key('Nx', 13)
+        self._check_key('Ny', 6)
+
+    def test__grid_points(self):
+        test_cube = self._make_test_cube(x_points=[1e6, 3e6, 5e6, 7e6],
+                                         y_points=[4e6, 9e6])
+        grid_definition_template_10(test_cube, self.mock_grib)
+        self._check_key("latitudeOfFirstGridPoint", 71676530)
+        self._check_key("longitudeOfFirstGridPoint", 287218188)
+        self._check_key("Dx", 2e9)
+        self._check_key("Dy", 5e9)
+
+    def test__template_specifics(self):
+        grid_definition_template_10(self.test_cube, self.mock_grib)
+        self._check_key("LaD", 39e6)
+
+    def test__scanmode(self):
+        grid_definition_template_10(self.test_cube, self.mock_grib)
+        self._check_key('iScansPositively', 1)
+        self._check_key('jScansPositively', 1)
+
+    def test__scanmode_reverse(self):
+        test_cube = self._make_test_cube(x_points=np.arange(7e6, 0, -1e6))
+        grid_definition_template_10(test_cube, self.mock_grib)
+        self._check_key('iScansPositively', 0)
+        self._check_key('jScansPositively', 1)
+
+    def test_projection_centre(self):
+        grid_definition_template_10(self.test_cube, self.mock_grib)
+        self._check_key('resolutionAndComponentFlags', 56)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_10.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_10.py
@@ -30,14 +30,9 @@ import numpy as np
 
 import iris.coords
 from iris.coord_systems import GeogCS, Mercator
-from iris.exceptions import TranslationError
 
 from iris_grib._save_rules import grid_definition_template_10
 from iris_grib.tests.unit.save_rules import GdtTestMixin
-
-
-class FakeGribError(Exception):
-    pass
 
 
 class Test(tests.IrisGribTest, GdtTestMixin):
@@ -83,24 +78,28 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         self._check_key('scaledValueOfEarthMinorAxis', 0)
 
     def test__grid_shape(self):
-        test_cube = self._make_test_cube(x_points=np.arange(13),
-                                         y_points=np.arange(6))
+        n_x_points = 13
+        n_y_points = 6
+        test_cube = self._make_test_cube(x_points=np.arange(n_x_points),
+                                         y_points=np.arange(n_y_points))
         grid_definition_template_10(test_cube, self.mock_grib)
-        self._check_key('Nx', 13)
-        self._check_key('Ny', 6)
+        self._check_key('Ni', n_x_points)
+        self._check_key('Nj', n_y_points)
 
     def test__grid_points(self):
         test_cube = self._make_test_cube(x_points=[1e6, 3e6, 5e6, 7e6],
                                          y_points=[4e6, 9e6])
         grid_definition_template_10(test_cube, self.mock_grib)
-        self._check_key("latitudeOfFirstGridPoint", 71676530)
-        self._check_key("longitudeOfFirstGridPoint", 287218188)
-        self._check_key("Dx", 2e9)
-        self._check_key("Dy", 5e9)
+        self._check_key("latitudeOfFirstGridPoint", 34727738)
+        self._check_key("longitudeOfFirstGridPoint", 9268240)
+        self._check_key("latitudeOfLastGridPoint", 63746266)
+        self._check_key("longitudeOfLastGridPoint", 64877681)
+        self._check_key("Di", 2e9)
+        self._check_key("Dj", 5e9)
 
     def test__template_specifics(self):
         grid_definition_template_10(self.test_cube, self.mock_grib)
-        self._check_key("LaD", 39e6)
+        self._check_key("LaD", 14e6)
 
     def test__scanmode(self):
         grid_definition_template_10(self.test_cube, self.mock_grib)
@@ -112,10 +111,6 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         grid_definition_template_10(test_cube, self.mock_grib)
         self._check_key('iScansPositively', 0)
         self._check_key('jScansPositively', 1)
-
-    def test_projection_centre(self):
-        grid_definition_template_10(self.test_cube, self.mock_grib)
-        self._check_key('resolutionAndComponentFlags', 56)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds functionality to save cubes on the Mercator projection to GRIB2, grid definition template 10.

Thanks to @kaedonkers for doing most of the work represented here!