### PR TITLE
Soft deps in setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,7 @@ branch = True
 omit = 
     setup.py
     iris_grib/tests/*
-    .eggs/
+    .eggs/*
 
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ branch = True
 omit = 
     setup.py
     iris_grib/tests/*
+    .eggs/
 
 
 [report]

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -26,7 +26,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import datetime
-import distutils.version
 import math  # for fmod
 import warnings
 
@@ -882,15 +881,3 @@ def save_messages(messages, target, append=False):
         # (this bit is common to the pp and grib savers...)
         if isinstance(target, six.string_types):
             grib_file.close()
-
-
-def _confirm_iris_mercator_support():
-    # Check that Iris version is at least 2.1, required for 'standard_parallel'
-    # support in the Mercator coord-system.
-    # This is a temporary fix allowing us to state Iris>=2.0 as a dependency,
-    # required for this release because Iris 2.1 is not yet available.
-    iris_version = distutils.version.LooseVersion(iris.__version__)
-    min_mercator_version = '2.1.0'
-    if iris_version < min_mercator_version:
-        msg = 'Support for Mercator projections requires Iris version >= {}'
-        raise ValueError(msg.format(min_mercator_version))

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -26,6 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import datetime
+import distutils.version
 import math  # for fmod
 import warnings
 
@@ -881,3 +882,15 @@ def save_messages(messages, target, append=False):
         # (this bit is common to the pp and grib savers...)
         if isinstance(target, six.string_types):
             grib_file.close()
+
+
+def _confirm_iris_mercator_support():
+    # Check that Iris version is at least 2.1, required for 'standard_parallel'
+    # support in the Mercator coord-system.
+    # This is a temporary fix allowing us to state Iris>=2.0 as a dependency,
+    # required for this release because Iris 2.1 is not yet available.
+    iris_version = distutils.version.LooseVersion(iris.__version__)
+    min_mercator_version = '2.1.0'
+    if iris_version < min_mercator_version:
+        msg = 'Support for Mercator projections requires Iris version >= {}'
+        raise ValueError(msg.format(min_mercator_version))

--- a/iris_grib/_iris_mercator_support.py
+++ b/iris_grib/_iris_mercator_support.py
@@ -1,0 +1,40 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of iris-grib.
+#
+# iris-grib is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-grib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Temporary module to check for the extended Mercator class in Iris,
+which iris-grib requires for its Mercator support.
+
+"""
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six
+
+import distutils.version
+
+import iris
+
+
+def confirm_extended_mercator_supported():
+    # Check that Iris version is at least 2.1, required for 'standard_parallel'
+    # support in the Mercator coord-system.
+    # This is a temporary fix allowing us to state Iris>=2.0 as a dependency,
+    # required for this release because Iris 2.1 is not yet available.
+    iris_version = distutils.version.LooseVersion(iris.__version__)
+    min_mercator_version = '2.1.0'
+    if iris_version < min_mercator_version:
+        msg = 'Support for Mercator projections requires Iris version >= {}'
+        raise ValueError(msg.format(min_mercator_version))

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -43,6 +43,7 @@ from iris.fileformats.rules import ConversionMetadata, Factory, Reference, \
     ReferenceTarget
 from iris.util import _is_circular
 
+from . import _confirm_iris_mercator_support
 from ._grib1_load_rules import grib1_convert
 from .message import GribMessage
 
@@ -746,6 +747,9 @@ def grid_definition_template_10(section, metadata):
     # intersects the Earth
     standard_parallel = section['LaD'] * _GRID_ACCURACY_IN_DEGREES
 
+    # Check and raise a more intelligible error, if the Iris version is too old
+    # to support the Mercator 'standard_parallel' keyword.
+    _confirm_iris_mercator_support()
     cs = icoord_systems.Mercator(standard_parallel=standard_parallel,
                                  ellipsoid=geog_cs)
 

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -43,7 +43,7 @@ from iris.fileformats.rules import ConversionMetadata, Factory, Reference, \
     ReferenceTarget
 from iris.util import _is_circular
 
-from . import _confirm_iris_mercator_support
+from ._iris_mercator_support import confirm_extended_mercator_supported
 from ._grib1_load_rules import grib1_convert
 from .message import GribMessage
 
@@ -749,7 +749,7 @@ def grid_definition_template_10(section, metadata):
 
     # Check and raise a more intelligible error, if the Iris version is too old
     # to support the Mercator 'standard_parallel' keyword.
-    _confirm_iris_mercator_support()
+    confirm_extended_mercator_supported()
     cs = icoord_systems.Mercator(standard_parallel=standard_parallel,
                                  ellipsoid=geog_cs)
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -39,7 +39,7 @@ from iris.coord_systems import (GeogCS, RotatedGeogCS, Mercator,
                                 TransverseMercator, LambertConformal)
 import iris.exceptions
 
-from . import _confirm_iris_mercator_support
+from ._iris_mercator_support import confirm_extended_mercator_supported
 from . import grib_phenom_translation as gptx
 from ._load_convert import (_STATISTIC_TYPE_NAMES, _TIME_RANGE_UNITS)
 from iris.util import is_regular, regular_step
@@ -506,7 +506,7 @@ def grid_definition_template_10(cube, grib):
 
     # Check and raise a more intelligible error, if the Iris version is too old
     # to support the Mercator 'standard_parallel' property.
-    _confirm_iris_mercator_support()
+    confirm_extended_mercator_supported()
     # Encode the latitude at which the projection intersects the Earth.
     gribapi.grib_set(grib, 'LaD',
                      cs.standard_parallel / _DEFAULT_DEGREES_UNITS)

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -39,6 +39,7 @@ from iris.coord_systems import (GeogCS, RotatedGeogCS, Mercator,
                                 TransverseMercator, LambertConformal)
 import iris.exceptions
 
+from . import _confirm_iris_mercator_support
 from . import grib_phenom_translation as gptx
 from ._load_convert import (_STATISTIC_TYPE_NAMES, _TIME_RANGE_UNITS)
 from iris.util import is_regular, regular_step
@@ -503,6 +504,9 @@ def grid_definition_template_10(cube, grib):
     gribapi.grib_set(grib, "longitudeOfLastGridPoint",
                      int(np.round(last_x / _DEFAULT_DEGREES_UNITS)))
 
+    # Check and raise a more intelligible error, if the Iris version is too old
+    # to support the Mercator 'standard_parallel' property.
+    _confirm_iris_mercator_support()
     # Encode the latitude at which the projection intersects the Earth.
     gribapi.grib_set(grib, 'LaD',
                      cs.standard_parallel / _DEFAULT_DEGREES_UNITS)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+import distutils
 import os
 import os.path
 from setuptools import setup
@@ -58,11 +59,11 @@ def file_walk_relative(top, remove=''):
 
 
 def available_iris():
-    try:
+    import iris
+    if iris.__version__ >= distutils.version.LooseVersion('2.1.0'):
         return 'scitools-iris==2.1.*'
-    except:
+    else:
         return 'scitools-iris>=2.0.*'
-
 
 setup_args = dict(
     name             = name,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-import distutils
 import os
 import os.path
 from setuptools import setup
@@ -58,13 +57,6 @@ def file_walk_relative(top, remove=''):
             yield os.path.join(root, file).replace(remove, '')
 
 
-def available_iris():
-    import iris
-    if iris.__version__ >= distutils.version.LooseVersion('2.1.0'):
-        return 'scitools-iris==2.1.*'
-    else:
-        return 'scitools-iris>=2.0.*'
-
 setup_args = dict(
     name             = name,
     version          = extract_version(),
@@ -87,7 +79,12 @@ setup_args = dict(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires = [available_iris(), 'eccodes'],
+    # NOTE: This Iris version requirement is a purely temporary measure :
+    # Iris>=2.1 is needed for Mercator support, but this is not yet available,
+    # so 'iris_grib._confirm_iris_mercator_support' performs a runtime version
+    # check instead + raises an error if required.
+    # TODO: update Iris version and remove runtime checking, in future release.
+    install_requires = ['scitools-iris>=2.0.*', 'eccodes'],
     extras_require = {
         'test:python_version=="2.7"': ['mock'],
     },

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def file_walk_relative(top, remove=''):
 
 def available_iris():
     try:
-        return 'scitools-iris=2.1.*'
+        return 'scitools-iris==2.1.*'
     except:
         return 'scitools-iris>=2.0.*'
 
@@ -86,7 +86,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires = [available_iris(), 'python-eccodes'],
+    install_requires = [available_iris(), 'eccodes'],
     extras_require = {
         'test:python_version=="2.7"': ['mock'],
     },

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,13 @@ def file_walk_relative(top, remove=''):
             yield os.path.join(root, file).replace(remove, '')
 
 
+def available_iris():
+    try:
+        return 'scitools-iris=2.1.*'
+    except:
+        return 'scitools-iris>=2.0.*'
+
+
 setup_args = dict(
     name             = name,
     version          = extract_version(),
@@ -79,10 +86,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires = [
-        #        'iris>=1.9,<2',
-        # Also: the ECMWF GRIB API
-    ],
+    install_requires = [available_iris(), 'python-eccodes'],
     extras_require = {
         'test:python_version=="2.7"': ['mock'],
     },


### PR DESCRIPTION
Popped a little function in the setup.py to look for iris 2.1 because that would be best, but if it's not available then it will install using iris 2.0 (or later).

Also added the eccodes dependency.  gribapi lives in python-eccodes, but I guess the (official?) package name is actually just eccodes.