### PR TITLE
added explicit flag to conda env list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
   # Install iris-grib's dependencies
   # --------------------------------
   - conda install --quiet --yes python=${python} iris python-eccodes numpy cartopy mock filelock pep8;
-  - conda list
+  - conda list --explicit;
+  - conda info -a;
 
   # Download iris-test-data
   # --------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ install:
   # Install iris-grib's dependencies
   # --------------------------------
   - conda install --quiet --yes python=${python} iris python-eccodes numpy cartopy mock filelock pep8;
-  - conda list --explicit;
-  - conda info -a;
+  - conda list
 
   # Download iris-test-data
   # --------------------------------
@@ -47,7 +46,7 @@ install:
 
   # Summarise the environment
   # -------------------------
-  - conda list
+  - conda list --explicit
 
 script:
   # Ensure we can import iris_grib and that the tests pass

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   # Install iris-grib's dependencies
   # --------------------------------
   - conda install --quiet --yes python=${python} iris python-eccodes numpy cartopy mock filelock pep8;
-  - conda list
+  - conda list --explicit
 
   # Download iris-test-data
   # --------------------------------
@@ -46,7 +46,7 @@ install:
 
   # Summarise the environment
   # -------------------------
-  - conda list --explicit
+  - conda list
 
 script:
   # Ensure we can import iris_grib and that the tests pass


### PR DESCRIPTION
- Added `--explicit` to conda env list so that we can grab the environment manifest of each run to reproduce it.
- Added `conda info -a` to list all info.  Not committed to this addition, might be worthwhile though.