### PR TITLE
Get iris-grib working in Python 3 !

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,18 @@ install:
 
   # Install iris-grib's dependencies
   # --------------------------------
-  # If running in Python 2, install Python2-only python-eccodes.
-  - if [[ "$python" == "2.7" ]]; then
+  # If running in Python 2, install Python2-only python-eccodes, otherwise we
+  # install the Python3-only eccodes-python via pip.
+  - if [[ "${python}" == "2.7" ]]; then
         export ECCODES_DEPS="python-eccodes";
-    fi
-
-  # If running in Python 3, we will install Python3-only eccodes-python via pip.
-  - if [[ "$python" == "3.6" ]]; then
+    else
         export ECCODES_DEPS="eccodes pip";
     fi
 
-  - conda install --quiet --yes python=${python} iris numpy cartopy mock filelock pep8 $ECCODES_DEPS;
+  - conda install --quiet --yes python=${python} iris numpy cartopy mock filelock pep8 ${ECCODES_DEPS};
     
   # If running in Python 3, install eccodes-python and check the installation.
-  - if [[ "$python" == "3.6" ]]; then
+  - if [[ "${python}" != "2.7" ]]; then
         pip install eccodes-python;
         python -m eccodes selfcheck;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 env:
   - python=2.7
+  - python=3.6
 
 install:
   # Fetch and install conda
@@ -16,7 +17,24 @@ install:
 
   # Install iris-grib's dependencies
   # --------------------------------
-  - conda install --quiet --yes python=${python} iris python-eccodes numpy cartopy mock filelock pep8;
+  # If running in Python 2, install Python2-only python-eccodes.
+  - if [[ "$python" == "2.7" ]]; then
+        export ECCODES_DEPS="python-eccodes";
+    fi
+
+  # If running in Python 3, we will install Python3-only eccodes-python via pip.
+  - if [[ "$python" == "3.6" ]]; then
+        export ECCODES_DEPS="eccodes pip";
+    fi
+
+  - conda install --quiet --yes python=${python} iris numpy cartopy mock filelock pep8 $ECCODES_DEPS;
+    
+  # If running in Python 3, install eccodes-python and check the installation.
+  - if [[ "$python" == "3.6" ]]; then
+        pip install eccodes-python;
+        python -m eccodes selfcheck;
+    fi
+
   - conda list --explicit
 
   # Download iris-test-data
@@ -29,7 +47,7 @@ install:
 
   # Locate iris installation
   # ------------------------
-  - export IRIS_DIR=$(python -c "import iris; import os.path; print os.path.dirname(iris.__file__)")
+  - export IRIS_DIR=$(python -c "import iris; import os.path; print(os.path.dirname(iris.__file__))")
 
   # Poke site.cfg to reference iris-test-data
   - SITE_CFG=$IRIS_DIR/etc/site.cfg

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -44,7 +44,7 @@ from iris.exceptions import TranslationError, NotYetImplementedError
 from . import grib_phenom_translation as gptx
 from . import _save_rules
 from ._load_convert import convert as load_convert
-from .message import GribMessage
+from .message import GribMessage, grib_get_array_wrapper
 
 
 __version__ = '0.15.0dev0'
@@ -205,7 +205,8 @@ class GribWrapper(object):
             # we just get <type 'float'> as the type of the "values"
             # array...special case here...
             if key in ["values", "pv", "latitudes", "longitudes"]:
-                res = gribapi.grib_get_double_array(self.grib_message, key)
+                res = grib_get_array_wrapper(
+                        gribapi.grib_get_double_array(self.grib_message, key))
             elif key in ('typeOfFirstFixedSurface',
                          'typeOfSecondFixedSurface'):
                 res = np.int32(gribapi.grib_get_long(self.grib_message, key))
@@ -471,8 +472,9 @@ class GribWrapper(object):
             # get the distinct latitudes, and make sure they are sorted
             # (south-to-north) and then put them in the right direction
             # depending on the scan direction
-            latitude_points = gribapi.grib_get_double_array(
-                self.grib_message, 'distinctLatitudes').astype(np.float64)
+            latitude_points = grib_get_array_wrapper(
+                gribapi.grib_get_double_array(
+                    self.grib_message, 'distinctLatitudes')).astype(np.float64)
             latitude_points.sort()
             if not self.jScansPositively:
                 # we require latitudes north-to-south
@@ -691,7 +693,8 @@ def _longitude_is_cyclic(points):
 
 def _message_values(grib_message, shape):
     gribapi.grib_set_double(grib_message, 'missingValue', np.nan)
-    data = gribapi.grib_get_double_array(grib_message, 'values')
+    data = grib_get_array_wrapper(
+            gribapi.grib_get_double_array(grib_message, 'values'))
     data = data.reshape(shape)
 
     # Handle missing values in a sensible way.

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -225,7 +225,7 @@ class GribWrapper(object):
                 else:
                     emsg = "Unknown type for {} : {}"
                     raise ValueError(emsg.format(key, str(key_type)))
-        except gribapi.GribInternalError:
+        except gribapi.errors.GribInternalError:
             res = None
 
         # ...or is it in our list of extras?

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -44,7 +44,7 @@ from iris.exceptions import TranslationError, NotYetImplementedError
 from . import grib_phenom_translation as gptx
 from . import _save_rules
 from ._load_convert import convert as load_convert
-from .message import GribMessage, grib_get_array_wrapper
+from .message import GribMessage, _grib_get_array_wrapper
 
 
 __version__ = '0.15.0dev0'
@@ -205,7 +205,7 @@ class GribWrapper(object):
             # we just get <type 'float'> as the type of the "values"
             # array...special case here...
             if key in ["values", "pv", "latitudes", "longitudes"]:
-                res = grib_get_array_wrapper(
+                res = _grib_get_array_wrapper(
                         gribapi.grib_get_double_array(self.grib_message, key))
             elif key in ('typeOfFirstFixedSurface',
                          'typeOfSecondFixedSurface'):
@@ -472,7 +472,7 @@ class GribWrapper(object):
             # get the distinct latitudes, and make sure they are sorted
             # (south-to-north) and then put them in the right direction
             # depending on the scan direction
-            latitude_points = grib_get_array_wrapper(
+            latitude_points = _grib_get_array_wrapper(
                 gribapi.grib_get_double_array(
                     self.grib_message, 'distinctLatitudes')).astype(np.float64)
             latitude_points.sort()
@@ -693,7 +693,7 @@ def _longitude_is_cyclic(points):
 
 def _message_values(grib_message, shape):
     gribapi.grib_set_double(grib_message, 'missingValue', np.nan)
-    data = grib_get_array_wrapper(
+    data = _grib_get_array_wrapper(
             gribapi.grib_get_double_array(grib_message, 'values'))
     data = data.reshape(shape)
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -976,7 +976,8 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
             coeffs_array[n_lev - 1] = height
             coeffs_array[n_coeffs + n_lev - 1] = sigma
         pv_values = [float(el) for el in coeffs_array]
-        gribapi.grib_set(grib, "NV", n_coeffs * 2)
+        # eccodes does not support writing numpy.it64, cast to python int
+        gribapi.grib_set(grib, "NV", int(n_coeffs * 2))
         gribapi.grib_set_array(grib, "pv", pv_values)
 
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -976,7 +976,7 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
             coeffs_array[n_lev - 1] = height
             coeffs_array[n_coeffs + n_lev - 1] = sigma
         pv_values = [float(el) for el in coeffs_array]
-        # eccodes does not support writing numpy.it64, cast to python int
+        # eccodes does not support writing numpy.int64, cast to python int
         gribapi.grib_set(grib, "NV", int(n_coeffs * 2))
         gribapi.grib_set_array(grib, "pv", pv_values)
 

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -33,11 +33,10 @@ import numpy.ma as ma
 from iris._lazy_data import as_lazy_data
 from iris.exceptions import TranslationError
 
-
 _SUPPORTED_GRID_DEFINITIONS = (0, 1, 5, 10, 12, 20, 30, 40, 90)
 
 
-def grib_get_array_wrapper(f):
+def _grib_get_array_wrapper(f):
     """
     Converts what f returns into an array.
 
@@ -48,7 +47,9 @@ def grib_get_array_wrapper(f):
     is fixed.
 
     """
-    return np.array(f)
+    if not isinstance(f, np.ndarray):
+        f = np.asarray(f)
+    return f
 
 
 class _OpenFileRef(object):
@@ -461,13 +462,13 @@ class Section(object):
                        'scaledValueOfCentralWaveNumber',
                        'longitudes', 'latitudes')
         if key in vector_keys:
-            res = grib_get_array_wrapper(
+            res = _grib_get_array_wrapper(
                     gribapi.grib_get_array(self._message_id, key))
         elif key == 'bitmap':
             # The bitmap is stored as contiguous boolean bits, one bit for each
             # data point. GRIBAPI returns these as strings, so it must be
             # type-cast to return an array of ints (0, 1).
-            res = grib_get_array_wrapper(
+            res = _grib_get_array_wrapper(
                     gribapi.grib_get_array(self._message_id, key, int))
         elif key in ('typeOfFirstFixedSurface', 'typeOfSecondFixedSurface'):
             # By default these values are returned as unhelpful strings but
@@ -493,7 +494,7 @@ class Section(object):
         """
         vector_keys = ('longitudes', 'latitudes', 'distinctLatitudes')
         if key in vector_keys:
-            res = grib_get_array_wrapper(
+            res = _grib_get_array_wrapper(
                     gribapi.grib_get_array(self._message_id, key))
         else:
             res = self._get_value_or_missing(key)

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -33,7 +33,22 @@ import numpy.ma as ma
 from iris._lazy_data import as_lazy_data
 from iris.exceptions import TranslationError
 
+
 _SUPPORTED_GRID_DEFINITIONS = (0, 1, 5, 10, 12, 20, 30, 40, 90)
+
+
+def grib_get_array_wrapper(f):
+    """
+    Converts what f returns into an array.
+
+    When using eccodes-python, gribapi.grib_get_*array returns a list rather
+    than an array as expected.
+
+    This is intended as a *temporary* fix that wil be moved once eccodes-python
+    is fixed.
+
+    """
+    return np.array(f)
 
 
 class _OpenFileRef(object):
@@ -446,12 +461,14 @@ class Section(object):
                        'scaledValueOfCentralWaveNumber',
                        'longitudes', 'latitudes')
         if key in vector_keys:
-            res = gribapi.grib_get_array(self._message_id, key)
+            res = grib_get_array_wrapper(
+                    gribapi.grib_get_array(self._message_id, key))
         elif key == 'bitmap':
             # The bitmap is stored as contiguous boolean bits, one bit for each
             # data point. GRIBAPI returns these as strings, so it must be
             # type-cast to return an array of ints (0, 1).
-            res = gribapi.grib_get_array(self._message_id, key, int)
+            res = grib_get_array_wrapper(
+                    gribapi.grib_get_array(self._message_id, key, int))
         elif key in ('typeOfFirstFixedSurface', 'typeOfSecondFixedSurface'):
             # By default these values are returned as unhelpful strings but
             # we can use int representation to compare against instead.
@@ -476,7 +493,8 @@ class Section(object):
         """
         vector_keys = ('longitudes', 'latitudes', 'distinctLatitudes')
         if key in vector_keys:
-            res = gribapi.grib_get_array(self._message_id, key)
+            res = grib_get_array_wrapper(
+                    gribapi.grib_get_array(self._message_id, key))
         else:
             res = self._get_value_or_missing(key)
         return res


### PR DESCRIPTION
The eccodes 2.10 release includes Python 3 support.

This PR includes Python 3 in the testing matrix and thus highlights outstanding issues with iris-grib/eccodes/Python3

Known issues with Python 3 that work fine in Python 2:
- [x] **1) Can't set the key 'NV' as np.int64**
   **TESTS:** integration.save_rules.test_save_hybrid_coords (all tests in file)
- [x] **2) Problem with lazy loading of _data_ from files**
    **2.i) files with hybrid factory - problem loading orography field during factory creation**
   files: iris_grib/tests/testdata/faked_sample_hh_grib_data.grib2 and faked_sample_hp_grib_data.grib2
   **TESTS:** integration.load_convert.test_load_hybrid_coords (all tests in file) and integration.round_trip.test_hybrid_coords_round_trip (all tests in file)
    **2.ii)) Can load in file as cube, when trying to call the data it fails**
  files: iris_grib/tests/testdata/*.grib2, (excet CB which does work)
   **TESTS:** integration.round_trip/test_WAFC_mapping_round_trip all tests in file except CB.grib2)
 