### PR TITLE
Granularity for fixed surface arguments

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -2354,6 +2354,7 @@ def product_definition_section(section, metadata, discipline, tablesVersion,
     template = section['productDefinitionTemplateNumber']
 
     probability = None
+    includes_fixed_surface_keys = True
     if template == 0:
         # Process analysis or forecast at a horizontal level or
         # in a horizontal layer at a point in time.
@@ -2377,8 +2378,10 @@ def product_definition_section(section, metadata, discipline, tablesVersion,
         product_definition_template_15(section, metadata, rt_coord)
     elif template == 31:
         # Process satellite product.
+        includes_fixed_surface_keys = False
         product_definition_template_31(section, metadata, rt_coord)
     elif template == 32:
+        includes_fixed_surface_keys = False
         product_definition_template_32(section, metadata, rt_coord)
     elif template == 40:
         product_definition_template_40(section, metadata, rt_coord)
@@ -2389,13 +2392,23 @@ def product_definition_section(section, metadata, discipline, tablesVersion,
 
     # Translate GRIB2 phenomenon to CF phenomenon.
     if tablesVersion != _CODE_TABLES_MISSING:
-        translate_phenomenon(metadata, discipline,
-                             section['parameterCategory'],
-                             section['parameterNumber'],
-                             section['typeOfFirstFixedSurface'],
-                             section['scaledValueOfFirstFixedSurface'],
-                             section['typeOfSecondFixedSurface'],
-                             probability=probability)
+        translation_kwargs = {
+            'metadata': metadata,
+            'discipline': discipline,
+            'parameterCategory': section['parameterCategory'],
+            'parameterNumber': section['parameterNumber'],
+            'probability': probability
+        }
+
+        # Won't always be able to populate the below arguments - missing from some template definitions.
+        for section_key in [
+            'typeOfFirstFixedSurface',
+            'scaledValueOfFirstFixedSurface',
+            'typeOfSecondFixedSurface'
+        ]:
+            translation_kwargs[section_key] = section[section_key] if includes_fixed_surface_keys else None
+
+        translate_phenomenon(**translation_kwargs)
 
 
 ###############################################################################

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -2400,13 +2400,15 @@ def product_definition_section(section, metadata, discipline, tablesVersion,
             'probability': probability
         }
 
-        # Won't always be able to populate the below arguments - missing from some template definitions.
+        # Won't always be able to populate the below arguments -
+        # missing from some template definitions.
         for section_key in [
             'typeOfFirstFixedSurface',
             'scaledValueOfFirstFixedSurface',
             'typeOfSecondFixedSurface'
         ]:
-            translation_kwargs[section_key] = section[section_key] if includes_fixed_surface_keys else None
+            translation_kwargs[section_key] = \
+                section[section_key] if includes_fixed_surface_keys else None
 
         translate_phenomenon(**translation_kwargs)
 

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -2402,11 +2402,13 @@ def product_definition_section(section, metadata, discipline, tablesVersion,
 
         # Won't always be able to populate the below arguments -
         # missing from some template definitions.
-        for section_key in [
+        fixed_surface_keys = [
             'typeOfFirstFixedSurface',
             'scaledValueOfFirstFixedSurface',
             'typeOfSecondFixedSurface'
-        ]:
+        ]
+
+        for section_key in fixed_surface_keys:
             translation_kwargs[section_key] = \
                 section[section_key] if includes_fixed_surface_keys else None
 

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -56,11 +56,11 @@ class TestFixedSurfaces(Test):
         discipline = mock.sentinel.discipline
         tablesVersion = mock.sentinel.tablesVersion
         rt_coord = DimCoord(24, 'forecast_reference_time',
-                                        units='hours since epoch')
+                            units='hours since epoch')
         metadata = empty_metadata()
 
         # Use the section 4 from either product_definition_section #1 or #31.
-        # #1 contains fixed surface elements, #31 does not
+        # #1 contains fixed surface elements, #31 does not.
         templates = {0: template_0(), 31: template_31()}
         template_number = 0 if fs_is_expected else 31
         section_4 = templates[template_number]

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -19,12 +19,6 @@ Tests for function :func:`iris_grib._load_convert.product_definition_section`.
 
 """
 
-# QUESTIONS
-# tests here will overlap with individual template tests, as they are all
-#   called within product_definition_section. Is this a problem?
-# a lot of tests have unused imports, seemingly because they were copied from
-#   other tests. Is this standard practice?
-
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
@@ -39,20 +33,88 @@ from cf_units import Unit
 from iris.coords import DimCoord
 
 from iris_grib._load_convert import product_definition_section
+from iris_grib._load_convert import vertical_coords
 from iris_grib.grib_phenom_translation import _GribToCfDataClass
 
 from iris_grib.tests.unit.load_convert import empty_metadata
 from iris_grib.tests.unit.load_convert.test_product_definition_template_0 \
     import section_4 as template_0
+from iris_grib.tests.unit.load_convert.test_product_definition_template_31 \
+    import section_4 as template_31
+
 
 class Test(tests.IrisGribTest):
-    def test_fixed_surface_present(self):
-        rt_coord = mock.sentinel.observation_time
+    def setUp(self):
+        self.patch('warnings.warn')
+        # self.product_definition_section_patch = self.patch(
+        #     'iris_grib._load_convert.product_definition_section'
+        # )
+        # self.vertical_coords_patch = self.patch(
+        #     'iris_grib._load_convert.vertical_coords'
+        # )
+        self.translate_phenomenon_patch = self.patch(
+            'iris_grib._load_convert.translate_phenomenon'
+        )
+
+
+class TestFixedSurfaces(Test):
+    def generic_fixed_surface_test(self, fs_is_expected, fs_is_present):
+        discipline = mock.sentinel.discipline
+        tablesVersion = mock.sentinel.tablesVersion
+        rt_coord = DimCoord(24, 'forecast_reference_time',
+                                        units='hours since epoch')
         metadata = empty_metadata()
-        section_4 = template_0()
-        product_definition_section(section_4, metadata, rt_coord)
 
+        templates = {0: template_0(), 31: template_31()}
+        template_number = 0 if fs_is_expected else 31
+        section_4 = templates[template_number]
+        section_4.update({
+            'productDefinitionTemplateNumber': template_number,
+            'parameterCategory': None,
+            'parameterNumber': None
+        })
 
+        fixed_surface_keys = [
+            'typeOfFirstFixedSurface',
+            'scaledValueOfFirstFixedSurface',
+            'typeOfSecondFixedSurface'
+        ]
+        for key in fixed_surface_keys:
+            if fs_is_present and key not in section_4:
+                section_4[key] = template_0()[key]
+            elif (not fs_is_present) and key in section_4:
+                del section_4[key]
 
-    # def test_fixed_surface_absent:
+        def run_function():
+            product_definition_section(
+                section_4, metadata, discipline, tablesVersion, rt_coord)
 
+        if fs_is_expected and not fs_is_present:
+            with self.assertRaises(KeyError) as context:
+                run_function()
+            self.assertTrue('FixedSurface' in str(context.exception))
+        else:
+            run_function()
+            self.assertEqual(self.translate_phenomenon_patch.call_count, 1)
+            phenom_call_args = self.translate_phenomenon_patch.call_args[1]
+            for key in fixed_surface_keys:
+                if fs_is_expected:
+                    self.assertEqual(phenom_call_args[key], section_4[key])
+                else:
+                    self.assertEqual(phenom_call_args[key], None)
+
+    def test_fixed_surface_expected_present(self):
+        self.generic_fixed_surface_test(fs_is_expected=True,
+                                        fs_is_present=True)
+
+    def test_fixed_surface_expected_absent(self):
+        self.generic_fixed_surface_test(fs_is_expected=True,
+                                        fs_is_present=False)
+
+    def test_fixed_surface_ignored_present(self):
+        self.generic_fixed_surface_test(fs_is_expected=False,
+                                        fs_is_present=True)
+
+    def test_fixed_surface_ignored_absent(self):
+        self.generic_fixed_surface_test(fs_is_expected=False,
+                                        fs_is_present=False)

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -15,26 +15,19 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
 """
-Tests for function :func:`iris_grib._load_convert.product_definition_section`.
+Tests for `iris_grib._load_convert.product_definition_section`.
 
 """
 
 from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-from copy import deepcopy
 import mock
-
-from cf_units import Unit
 from iris.coords import DimCoord
-
 from iris_grib._load_convert import product_definition_section
-from iris_grib._load_convert import vertical_coords
-from iris_grib.grib_phenom_translation import _GribToCfDataClass
 
 from iris_grib.tests.unit.load_convert import empty_metadata
 from iris_grib.tests.unit.load_convert.test_product_definition_template_0 \
@@ -46,25 +39,28 @@ from iris_grib.tests.unit.load_convert.test_product_definition_template_31 \
 class Test(tests.IrisGribTest):
     def setUp(self):
         self.patch('warnings.warn')
-        # self.product_definition_section_patch = self.patch(
-        #     'iris_grib._load_convert.product_definition_section'
-        # )
-        # self.vertical_coords_patch = self.patch(
-        #     'iris_grib._load_convert.vertical_coords'
-        # )
         self.translate_phenomenon_patch = self.patch(
             'iris_grib._load_convert.translate_phenomenon'
         )
 
 
+# Tests focussing on the handling of fixed surface elements in section 4.
+# Expects/ignores depending on the template number.
 class TestFixedSurfaces(Test):
     def generic_fixed_surface_test(self, fs_is_expected, fs_is_present):
+        # Whether or not fixed surface elements are expected/present in the
+        # section 4 keys, most of the code is shared so we are using a single
+        # function with parameters.
+
+        # Prep placeholder variables for product_definition_section.
         discipline = mock.sentinel.discipline
         tablesVersion = mock.sentinel.tablesVersion
         rt_coord = DimCoord(24, 'forecast_reference_time',
                                         units='hours since epoch')
         metadata = empty_metadata()
 
+        # Use the section 4 from either product_definition_section #1 or #31.
+        # #1 contains fixed surface elements, #31 does not
         templates = {0: template_0(), 31: template_31()}
         template_number = 0 if fs_is_expected else 31
         section_4 = templates[template_number]
@@ -80,41 +76,59 @@ class TestFixedSurfaces(Test):
             'typeOfSecondFixedSurface'
         ]
         for key in fixed_surface_keys:
+            # Force the presence or absence of the fixed surface elements even
+            # when they're respectively ignored or expected.
             if fs_is_present and key not in section_4:
                 section_4[key] = template_0()[key]
             elif (not fs_is_present) and key in section_4:
                 del section_4[key]
 
         def run_function():
+            # For re-use in every type of test below.
             product_definition_section(
                 section_4, metadata, discipline, tablesVersion, rt_coord)
 
         if fs_is_expected and not fs_is_present:
+            # Should error since the expected keys are missing.
             with self.assertRaises(KeyError) as context:
                 run_function()
             self.assertTrue('FixedSurface' in str(context.exception))
         else:
+            # Should have a successful run for all other circumstances.
             run_function()
+            # Translate_phenomenon_patch is the end of the function,
+            # and should be able to accept None for the fixed surface
+            # arguments. So should always have run.
             self.assertEqual(self.translate_phenomenon_patch.call_count, 1)
             phenom_call_args = self.translate_phenomenon_patch.call_args[1]
             for key in fixed_surface_keys:
+                # Check whether None or actual values have been passed for
+                # the fixed surface arguments.
                 if fs_is_expected:
                     self.assertEqual(phenom_call_args[key], section_4[key])
                 else:
                     self.assertEqual(phenom_call_args[key], None)
 
     def test_fixed_surface_expected_present(self):
+        # Standard behaviour for most templates.
         self.generic_fixed_surface_test(fs_is_expected=True,
                                         fs_is_present=True)
 
+    def test_fixed_surface_ignored_absent(self):
+        # Standard behaviour for a few templates e.g. #31.
+        self.generic_fixed_surface_test(fs_is_expected=False,
+                                        fs_is_present=False)
+
     def test_fixed_surface_expected_absent(self):
+        # Unplanned combination, should result in an error.
         self.generic_fixed_surface_test(fs_is_expected=True,
                                         fs_is_present=False)
 
     def test_fixed_surface_ignored_present(self):
+        # Unplanned combination, should be handled same as 'ignored_absent'.
         self.generic_fixed_surface_test(fs_is_expected=False,
                                         fs_is_present=True)
 
-    def test_fixed_surface_ignored_absent(self):
-        self.generic_fixed_surface_test(fs_is_expected=False,
-                                        fs_is_present=False)
+
+if __name__ == '__main__':
+    tests.main()

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -71,6 +71,11 @@ class TestFixedSurfaces(tests.IrisGribTest):
         function with parameters.
         """
 
+        string_expected = 'Expected' if fs_is_expected else 'Unexpected'
+        string_present = 'Present' if fs_is_present else 'Absent'
+        print('Fixed Surface Keys *{}* and *{}*... '.format(string_expected,
+                                                            string_present))
+
         # Use the section 4 from either product_definition_section #1 or #31.
         # #0 contains fixed surface elements, #31 does not.
         template_number = 0 if fs_is_expected else 31
@@ -98,17 +103,18 @@ class TestFixedSurfaces(tests.IrisGribTest):
         if fs_is_expected and not fs_is_present:
             # Should error since the expected keys are missing.
             error_message = 'FixedSurface'
-            # with self.assertRaises(KeyError) as context:
             with six.assertRaisesRegex(self, KeyError, error_message):
                 run_function()
-            # self.assertTrue('FixedSurface' in str(context.exception))
         else:
             # Should have a successful run for all other circumstances.
-            run_function()
+
             # Translate_phenomenon_patch is the end of the function,
             # and should be able to accept None for the fixed surface
             # arguments. So should always have run.
-            self.assertEqual(self.translate_phenomenon_patch.call_count, 1)
+            previous_call_count = self.translate_phenomenon_patch.call_count
+            run_function()
+            self.assertEqual(self.translate_phenomenon_patch.call_count,
+                             previous_call_count + 1)
             phenom_call_args = self.translate_phenomenon_patch.call_args[1]
             for key in self.fixed_surface_keys:
                 # Check whether None or actual values have been passed for
@@ -118,7 +124,9 @@ class TestFixedSurfaces(tests.IrisGribTest):
                 else:
                     self.assertIsNone(phenom_call_args[key])
 
-    def test_all(self):
+        print('passed')
+
+    def test_all_combinations(self):
         """
         Test all combinations of fixed surface being expected/present
 
@@ -131,26 +139,6 @@ class TestFixedSurfaces(tests.IrisGribTest):
         """
         for pair in product([True, False], repeat=2):
             self._check_fixed_surface(*pair)
-
-    # def test_fixed_surface_expected_present(self):
-    #     # Standard behaviour for most templates.
-    #     self._check_fixed_surface(fs_is_expected=True,
-    #                               fs_is_present=True)
-    #
-    # def test_fixed_surface_ignored_absent(self):
-    #     # Standard behaviour for a few templates e.g. #31.
-    #     self._check_fixed_surface(fs_is_expected=False,
-    #                               fs_is_present=False)
-    #
-    # def test_fixed_surface_expected_absent(self):
-    #     # Unplanned combination, should result in an error.
-    #     self._check_fixed_surface(fs_is_expected=True,
-    #                               fs_is_present=False)
-    #
-    # def test_fixed_surface_ignored_present(self):
-    #     # Unplanned combination, should be handled same as 'ignored_absent'.
-    #     self._check_fixed_surface(fs_is_expected=False,
-    #                               fs_is_present=True)
 
 
 if __name__ == '__main__':

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -25,74 +25,83 @@ from __future__ import (absolute_import, division, print_function)
 # before importing anything else.
 import iris_grib.tests as tests
 
-import mock
 from iris.coords import DimCoord
-from iris_grib._load_convert import product_definition_section
+import mock
+import six
 
+from itertools import product
+
+from iris_grib._load_convert import product_definition_section
 from iris_grib.tests.unit.load_convert import empty_metadata
 from iris_grib.tests.unit.load_convert.test_product_definition_template_0 \
-    import section_4 as template_0
+    import section_4 as pdt_0_section_4
 from iris_grib.tests.unit.load_convert.test_product_definition_template_31 \
-    import section_4 as template_31
+    import section_4 as pdt_31_section_4
 
 
-class Test(tests.IrisGribTest):
+class TestFixedSurfaces(tests.IrisGribTest):
+    """
+    Tests focussing on the handling of fixed surface elements in section 4.
+    Expects/ignores depending on the template number.
+    """
     def setUp(self):
         self.patch('warnings.warn')
         self.translate_phenomenon_patch = self.patch(
             'iris_grib._load_convert.translate_phenomenon'
         )
 
-
-# Tests focussing on the handling of fixed surface elements in section 4.
-# Expects/ignores depending on the template number.
-class TestFixedSurfaces(Test):
-    def generic_fixed_surface_test(self, fs_is_expected, fs_is_present):
-        # Whether or not fixed surface elements are expected/present in the
-        # section 4 keys, most of the code is shared so we are using a single
-        # function with parameters.
-
         # Prep placeholder variables for product_definition_section.
-        discipline = mock.sentinel.discipline
-        tablesVersion = mock.sentinel.tablesVersion
-        rt_coord = DimCoord(24, 'forecast_reference_time',
-                            units='hours since epoch')
-        metadata = empty_metadata()
+        self.discipline = mock.sentinel.discipline
+        self.tablesVersion = mock.sentinel.tablesVersion
+        self.rt_coord = DimCoord(24, 'forecast_reference_time',
+                                 units='hours since epoch')
+        self.metadata = empty_metadata()
+
+        self.templates = {0: pdt_0_section_4(), 31: pdt_31_section_4()}
+        self.fixed_surface_keys = [
+            'typeOfFirstFixedSurface',
+            'scaledValueOfFirstFixedSurface',
+            'typeOfSecondFixedSurface'
+        ]
+
+    def _check_fixed_surface(self, fs_is_expected, fs_is_present):
+        """
+        Whether or not fixed surface elements are expected/present in the
+        section 4 keys, most of the code is shared so we are using a single
+        function with parameters.
+        """
 
         # Use the section 4 from either product_definition_section #1 or #31.
-        # #1 contains fixed surface elements, #31 does not.
-        templates = {0: template_0(), 31: template_31()}
+        # #0 contains fixed surface elements, #31 does not.
         template_number = 0 if fs_is_expected else 31
-        section_4 = templates[template_number]
+        section_4 = self.templates[template_number]
         section_4.update({
             'productDefinitionTemplateNumber': template_number,
             'parameterCategory': None,
             'parameterNumber': None
         })
 
-        fixed_surface_keys = [
-            'typeOfFirstFixedSurface',
-            'scaledValueOfFirstFixedSurface',
-            'typeOfSecondFixedSurface'
-        ]
-        for key in fixed_surface_keys:
+        for key in self.fixed_surface_keys:
             # Force the presence or absence of the fixed surface elements even
             # when they're respectively ignored or expected.
             if fs_is_present and key not in section_4:
-                section_4[key] = template_0()[key]
+                section_4[key] = pdt_0_section_4()[key]
             elif (not fs_is_present) and key in section_4:
                 del section_4[key]
 
         def run_function():
             # For re-use in every type of test below.
             product_definition_section(
-                section_4, metadata, discipline, tablesVersion, rt_coord)
+                section_4, self.metadata, self.discipline, self.tablesVersion,
+                self.rt_coord)
 
         if fs_is_expected and not fs_is_present:
             # Should error since the expected keys are missing.
-            with self.assertRaises(KeyError) as context:
+            error_message = 'FixedSurface'
+            # with self.assertRaises(KeyError) as context:
+            with six.assertRaisesRegex(self, KeyError, error_message):
                 run_function()
-            self.assertTrue('FixedSurface' in str(context.exception))
+            # self.assertTrue('FixedSurface' in str(context.exception))
         else:
             # Should have a successful run for all other circumstances.
             run_function()
@@ -101,33 +110,47 @@ class TestFixedSurfaces(Test):
             # arguments. So should always have run.
             self.assertEqual(self.translate_phenomenon_patch.call_count, 1)
             phenom_call_args = self.translate_phenomenon_patch.call_args[1]
-            for key in fixed_surface_keys:
+            for key in self.fixed_surface_keys:
                 # Check whether None or actual values have been passed for
                 # the fixed surface arguments.
                 if fs_is_expected:
                     self.assertEqual(phenom_call_args[key], section_4[key])
                 else:
-                    self.assertEqual(phenom_call_args[key], None)
+                    self.assertIsNone(phenom_call_args[key])
 
-    def test_fixed_surface_expected_present(self):
-        # Standard behaviour for most templates.
-        self.generic_fixed_surface_test(fs_is_expected=True,
-                                        fs_is_present=True)
+    def test_all(self):
+        """
+        Test all combinations of fixed surface being expected/present
 
-    def test_fixed_surface_ignored_absent(self):
-        # Standard behaviour for a few templates e.g. #31.
-        self.generic_fixed_surface_test(fs_is_expected=False,
-                                        fs_is_present=False)
+        a. Expected and Present - standard behaviour for most templates
+        b. Expected and Absent - unplanned combination, should error
+        c. Unexpected and Present - unplanned combination, should be handled
+            identically to (d)
+        d. Unexpected and Absent - standard behaviour for a few templates
+            e.g. #31
+        """
+        for pair in product([True, False], repeat=2):
+            self._check_fixed_surface(*pair)
 
-    def test_fixed_surface_expected_absent(self):
-        # Unplanned combination, should result in an error.
-        self.generic_fixed_surface_test(fs_is_expected=True,
-                                        fs_is_present=False)
-
-    def test_fixed_surface_ignored_present(self):
-        # Unplanned combination, should be handled same as 'ignored_absent'.
-        self.generic_fixed_surface_test(fs_is_expected=False,
-                                        fs_is_present=True)
+    # def test_fixed_surface_expected_present(self):
+    #     # Standard behaviour for most templates.
+    #     self._check_fixed_surface(fs_is_expected=True,
+    #                               fs_is_present=True)
+    #
+    # def test_fixed_surface_ignored_absent(self):
+    #     # Standard behaviour for a few templates e.g. #31.
+    #     self._check_fixed_surface(fs_is_expected=False,
+    #                               fs_is_present=False)
+    #
+    # def test_fixed_surface_expected_absent(self):
+    #     # Unplanned combination, should result in an error.
+    #     self._check_fixed_surface(fs_is_expected=True,
+    #                               fs_is_present=False)
+    #
+    # def test_fixed_surface_ignored_present(self):
+    #     # Unplanned combination, should be handled same as 'ignored_absent'.
+    #     self._check_fixed_surface(fs_is_expected=False,
+    #                               fs_is_present=True)
 
 
 if __name__ == '__main__':

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -71,11 +71,6 @@ class TestFixedSurfaces(tests.IrisGribTest):
         function with parameters.
         """
 
-        string_expected = 'Expected' if fs_is_expected else 'Unexpected'
-        string_present = 'Present' if fs_is_present else 'Absent'
-        print('Fixed Surface Keys *{}* and *{}*... '.format(string_expected,
-                                                            string_present))
-
         # Use the section 4 from either product_definition_section #1 or #31.
         # #0 contains fixed surface elements, #31 does not.
         template_number = 0 if fs_is_expected else 31
@@ -123,8 +118,6 @@ class TestFixedSurfaces(tests.IrisGribTest):
                     self.assertEqual(phenom_call_args[key], section_4[key])
                 else:
                     self.assertIsNone(phenom_call_args[key])
-
-        print('passed')
 
     def test_all_combinations(self):
         """

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -1,0 +1,58 @@
+# (C) British Crown Copyright 2014 - 2019, Met Office
+#
+# This file is part of iris-grib.
+#
+# iris-grib is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-grib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests for function :func:`iris_grib._load_convert.product_definition_section`.
+
+"""
+
+# QUESTIONS
+# tests here will overlap with individual template tests, as they are all
+#   called within product_definition_section. Is this a problem?
+# a lot of tests have unused imports, seemingly because they were copied from
+#   other tests. Is this standard practice?
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# import iris_grib.tests first so that some things can be initialised
+# before importing anything else.
+import iris_grib.tests as tests
+
+from copy import deepcopy
+import mock
+
+from cf_units import Unit
+from iris.coords import DimCoord
+
+from iris_grib._load_convert import product_definition_section
+from iris_grib.grib_phenom_translation import _GribToCfDataClass
+
+from iris_grib.tests.unit.load_convert import empty_metadata
+from iris_grib.tests.unit.load_convert.test_product_definition_template_0 \
+    import section_4 as template_0
+
+class Test(tests.IrisGribTest):
+    def test_fixed_surface_present(self):
+        rt_coord = mock.sentinel.observation_time
+        metadata = empty_metadata()
+        section_4 = template_0()
+        product_definition_section(section_4, metadata, rt_coord)
+
+
+
+    # def test_fixed_surface_absent:
+

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
@@ -38,7 +38,7 @@ from iris_grib._load_convert import product_definition_template_31
 
 
 def section_4():
-    # also needed for test_product_definition_section.py
+    # Also needed for test_product_definition_section.py.
     series = mock.sentinel.satelliteSeries
     number = mock.sentinel.satelliteNumber
     instrument = mock.sentinel.instrumentType

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
@@ -37,6 +37,19 @@ from iris_grib.tests.unit.load_convert import empty_metadata
 from iris_grib._load_convert import product_definition_template_31
 
 
+def section_4():
+    # also needed for test_product_definition_section.py
+    series = mock.sentinel.satelliteSeries
+    number = mock.sentinel.satelliteNumber
+    instrument = mock.sentinel.instrumentType
+    return {'NB': 1,
+            'satelliteSeries': series,
+            'satelliteNumber': number,
+            'instrumentType': instrument,
+            'scaleFactorOfCentralWaveNumber': 1,
+            'scaledValueOfCentralWaveNumber': 12}
+
+
 class Test(tests.IrisGribTest):
     def setUp(self):
         self.patch('warnings.warn')
@@ -47,16 +60,8 @@ class Test(tests.IrisGribTest):
 
     def test(self):
         # Prepare the arguments.
-        series = mock.sentinel.satelliteSeries
-        number = mock.sentinel.satelliteNumber
-        instrument = mock.sentinel.instrumentType
         rt_coord = mock.sentinel.observation_time
-        section = {'NB': 1,
-                   'satelliteSeries': series,
-                   'satelliteNumber': number,
-                   'instrumentType': instrument,
-                   'scaleFactorOfCentralWaveNumber': 1,
-                   'scaledValueOfCentralWaveNumber': 12}
+        section = section_4()
 
         # Call the function.
         metadata = empty_metadata()


### PR DESCRIPTION
product_definition_section will no longer always try to populate the fixed surface arguments for translate_phenomenon - not available in some templates, in which case populate with None

Ran iris-grib unit tests afterwards - 364 passed, 21 were ignored as they needed external data (total 385)