### PR TITLE
Fix to read grib files obeying 'resolutionAndComponentFlags'

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2018, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -498,6 +498,14 @@ def ellipsoid_geometry(section):
     return major, minor, radius
 
 
+def _calculate_increment(first_grid_point, last_grid_point, num_intervals):
+    # Calculates the directional increment from the difference between
+    # the grid point values divided by the total number of intervals.
+    # Required by template 0 & 40 when no increment values are provided.
+
+    return math.fabs(last_grid_point - first_grid_point) / num_intervals
+
+
 def grid_definition_template_0_and_1(section, metadata, y_name, x_name, cs):
     """
     Translate templates representing regularly spaced latitude/longitude
@@ -533,8 +541,16 @@ def grid_definition_template_0_and_1(section, metadata, y_name, x_name, cs):
 
     scan = scanning_mode(section['scanningMode'])
 
+    # Set resoultion flags
+    res_flags = resolution_flags(section['resolutionAndComponentFlags'])
+
     # Calculate longitude points.
-    x_inc = section['iDirectionIncrement'] * _GRID_ACCURACY_IN_DEGREES
+    x_inc = (section['iDirectionIncrement']
+             if res_flags.i_increments_given
+             else _calculate_increment(section['longitudeOfFirstGridPoint'],
+                                       section['longitudeOfLastGridPoint'],
+                                       section['Ni'] - 1))
+    x_inc *= _GRID_ACCURACY_IN_DEGREES
     x_offset = section['longitudeOfFirstGridPoint'] * _GRID_ACCURACY_IN_DEGREES
     x_direction = -1 if scan.i_negative else 1
     Ni = section['Ni']
@@ -544,7 +560,12 @@ def grid_definition_template_0_and_1(section, metadata, y_name, x_name, cs):
     circular = _is_circular(x_points, 360.0)
 
     # Calculate latitude points.
-    y_inc = section['jDirectionIncrement'] * _GRID_ACCURACY_IN_DEGREES
+    y_inc = (section['jDirectionIncrement']
+             if res_flags.j_increments_given
+             else _calculate_increment(section['latitudeOfFirstGridPoint'],
+                                       section['latitudeOfLastGridPoint'],
+                                       section['Nj'] - 1))
+    y_inc *= _GRID_ACCURACY_IN_DEGREES
     y_offset = section['latitudeOfFirstGridPoint'] * _GRID_ACCURACY_IN_DEGREES
     y_direction = 1 if scan.j_positive else -1
     Nj = section['Nj']
@@ -1047,8 +1068,16 @@ def grid_definition_template_40_regular(section, metadata, cs):
     """
     scan = scanning_mode(section['scanningMode'])
 
+    # Set resolution flags
+    res_flags = resolution_flags(section['resolutionAndComponentFlags'])
+
     # Calculate longitude points.
-    x_inc = section['iDirectionIncrement'] * _GRID_ACCURACY_IN_DEGREES
+    x_inc = (section['iDirectionIncrement']
+             if res_flags.i_increments_given
+             else _calculate_increment(section['longitudeOfFirstGridPoint'],
+                                       section['longitudeOfLastGridPoint'],
+                                       section['Ni'] - 1))
+    x_inc *= _GRID_ACCURACY_IN_DEGREES
     x_offset = section['longitudeOfFirstGridPoint'] * _GRID_ACCURACY_IN_DEGREES
     x_direction = -1 if scan.i_negative else 1
     Ni = section['Ni']

--- a/iris_grib/tests/unit/load_convert/test_calculate_increment.py
+++ b/iris_grib/tests/unit/load_convert/test_calculate_increment.py
@@ -1,0 +1,43 @@
+# (C) British Crown Copyright 2014 - 2019, Met Office
+#
+# This file is part of iris-grib.
+#
+# iris-grib is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-grib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for `iris_grib._load_convert._calculate_increment`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris_grib.tests first so that some things can be initialised before
+# importing anything else.
+import iris_grib.tests as tests
+
+from iris_grib._load_convert import _calculate_increment
+
+
+class Test(tests.IrisGribTest):
+    def test_negative(self):
+        result = _calculate_increment(-15, -5, 10)
+        self.assertEqual(result, 1)
+
+    def test_positive(self):
+        result = _calculate_increment(-5, 5, 10)
+        self.assertEqual(result, 1)
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/iris_grib/tests/unit/load_convert/test_calculate_increment.py
+++ b/iris_grib/tests/unit/load_convert/test_calculate_increment.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2019, Met Office
+# (C) British Crown Copyright 2019, Met Office
 #
 # This file is part of iris-grib.
 #

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_0_and_1.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_0_and_1.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2019, Met Office
+# (C) British Crown Copyright 2016 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_40.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_40.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2017, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -56,6 +56,7 @@ class Test_regular(tests.IrisGribTest):
             'scaledValueOfEarthMinorAxis': MDI,
             'iDirectionIncrement': 22500000,
             'longitudeOfFirstGridPoint': 0,
+            'resolutionAndComponentFlags': 32,
             'Ni': 16,
             'scanningMode': 0b01000000,
             'distinctLatitudes': np.array([-73.79921363, -52.81294319,


### PR DESCRIPTION
This fix allows iris to obey the 'resolutionAndComponentFlags' value within GRIB files. This value specifies whether iris should be looking for i/j increments within the given GRIB file, and if they aren't specified (value of 0 is set) provides a method of calculating the increments via other means.   
