### PR TITLE
Test most recent eccodes release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
     
   # If running in Python 3, install eccodes-python and check the installation.
   - if [[ "${python}" != "2.7" ]]; then
-        pip install eccodes-python;
+        pip install eccodes-python>=0.9.1;
         python -m eccodes selfcheck;
     fi
 

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -44,7 +44,7 @@ from iris.exceptions import TranslationError, NotYetImplementedError
 from . import grib_phenom_translation as gptx
 from . import _save_rules
 from ._load_convert import convert as load_convert
-from .message import GribMessage, _grib_get_array_wrapper
+from .message import GribMessage
 
 
 __version__ = '0.14.1'
@@ -205,8 +205,7 @@ class GribWrapper(object):
             # we just get <type 'float'> as the type of the "values"
             # array...special case here...
             if key in ["values", "pv", "latitudes", "longitudes"]:
-                res = _grib_get_array_wrapper(
-                        gribapi.grib_get_double_array(self.grib_message, key))
+                res = gribapi.grib_get_double_array(self.grib_message, key)
             elif key in ('typeOfFirstFixedSurface',
                          'typeOfSecondFixedSurface'):
                 res = np.int32(gribapi.grib_get_long(self.grib_message, key))
@@ -472,9 +471,8 @@ class GribWrapper(object):
             # get the distinct latitudes, and make sure they are sorted
             # (south-to-north) and then put them in the right direction
             # depending on the scan direction
-            latitude_points = _grib_get_array_wrapper(
-                gribapi.grib_get_double_array(
-                    self.grib_message, 'distinctLatitudes')).astype(np.float64)
+            latitude_points = gribapi.grib_get_double_array(
+                    self.grib_message, 'distinctLatitudes').astype(np.float64)
             latitude_points.sort()
             if not self.jScansPositively:
                 # we require latitudes north-to-south
@@ -693,8 +691,7 @@ def _longitude_is_cyclic(points):
 
 def _message_values(grib_message, shape):
     gribapi.grib_set_double(grib_message, 'missingValue', np.nan)
-    data = _grib_get_array_wrapper(
-            gribapi.grib_get_double_array(grib_message, 'values'))
+    data = gribapi.grib_get_double_array(grib_message, 'values')
     data = data.reshape(shape)
 
     # Handle missing values in a sensible way.

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -36,22 +36,6 @@ from iris.exceptions import TranslationError
 _SUPPORTED_GRID_DEFINITIONS = (0, 1, 5, 10, 12, 20, 30, 40, 90)
 
 
-def _grib_get_array_wrapper(f):
-    """
-    Converts what f returns into an array.
-
-    When using eccodes-python, gribapi.grib_get_*array returns a list rather
-    than an array as expected.
-
-    This is intended as a *temporary* fix that wil be moved once eccodes-python
-    is fixed.
-
-    """
-    if not isinstance(f, np.ndarray):
-        f = np.asarray(f)
-    return f
-
-
 class _OpenFileRef(object):
     """
     A reference to an open file that ensures that the file is closed
@@ -462,14 +446,12 @@ class Section(object):
                        'scaledValueOfCentralWaveNumber',
                        'longitudes', 'latitudes')
         if key in vector_keys:
-            res = _grib_get_array_wrapper(
-                    gribapi.grib_get_array(self._message_id, key))
+            res = gribapi.grib_get_array(self._message_id, key)
         elif key == 'bitmap':
             # The bitmap is stored as contiguous boolean bits, one bit for each
             # data point. GRIBAPI returns these as strings, so it must be
             # type-cast to return an array of ints (0, 1).
-            res = _grib_get_array_wrapper(
-                    gribapi.grib_get_array(self._message_id, key, int))
+            res = gribapi.grib_get_array(self._message_id, key, int)
         elif key in ('typeOfFirstFixedSurface', 'typeOfSecondFixedSurface'):
             # By default these values are returned as unhelpful strings but
             # we can use int representation to compare against instead.
@@ -494,8 +476,7 @@ class Section(object):
         """
         vector_keys = ('longitudes', 'latitudes', 'distinctLatitudes')
         if key in vector_keys:
-            res = _grib_get_array_wrapper(
-                    gribapi.grib_get_array(self._message_id, key))
+            res = gribapi.grib_get_array(self._message_id, key)
         else:
             res = self._get_value_or_missing(key)
         return res


### PR DESCRIPTION
Eccodes v2.13.0 was just released, so this is to test iris-grib with that release.
Furthermore, eccodes-python has been updated such that things like `grib_get_double_array` returns arrays as we would expect, rather than a list, and as such I have pulled out those related workarounds.

FYI @bjlittle 