### PR TITLE
Fix the name of GribInternalError

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -226,7 +226,7 @@ class GribWrapper(object):
                 else:
                     emsg = "Unknown type for {} : {}"
                     raise ValueError(emsg.format(key, str(key_type)))
-        except gribapi.errors.GribInternalError:
+        except gribapi.GribInternalError:
             res = None
 
         # ...or is it in our list of extras?


### PR DESCRIPTION
`gribapi` has no attribute `errors`, `GribInternalError` is contained directly in `gribapi`.