### PR TITLE
Depth coordinate

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -881,6 +881,12 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
         output_unit = cf_units.Unit("m")
         v_coord = cube.coord("height")
 
+    # depth
+    elif cube.coords("depth"):
+        grib_v_code = 106
+        output_unit = cf_units.Unit('m')
+        v_coord = cube.coord("depth")
+        
     elif cube.coords("air_potential_temperature"):
         grib_v_code = 107
         output_unit = cf_units.Unit('K')

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -886,7 +886,7 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
         grib_v_code = 106
         output_unit = cf_units.Unit('m')
         v_coord = cube.coord("depth")
-        
+
     elif cube.coords("air_potential_temperature"):
         grib_v_code = 107
         output_unit = cf_units.Unit('K')

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -81,7 +81,7 @@ class Test(tests.IrisGribTest):
         cube = iris.cube.Cube([0])
         cube.add_aux_coord(iris.coords.AuxCoord(
             1, long_name='depth', units='m',
-            bounds=np.array([0. , 2]), attributes={'positive': 'down'}))
+            bounds=np.array([0., 2]), attributes={'positive': 'down'}))
         grib = gribapi.grib_new_from_samples("GRIB2")
         set_fixed_surfaces(cube, grib)
         self.assertEqual(
@@ -96,6 +96,7 @@ class Test(tests.IrisGribTest):
         self.assertEqual(
             gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
             106)
+
 
 if __name__ == "__main__":
     tests.main()

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -81,7 +81,7 @@ class Test(tests.IrisGribTest):
         cube = iris.cube.Cube([0])
         cube.add_aux_coord(iris.coords.AuxCoord(
             1, long_name='depth', units='m',
-            bounds=np.array([0. , 2]), attributes={'positive': 'down'})
+            bounds=np.array([0. , 2]), attributes={'positive': 'down'})))
         grib = gribapi.grib_new_from_samples("GRIB2")
         set_fixed_surfaces(cube, grib)
         self.assertEqual(

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -77,6 +77,29 @@ class Test(tests.IrisGribTest):
             gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
             107)
 
+    def test_depth(self):
+        cube = iris.cube.Cube([0])
+        cube.add_aux_coord(iris.coords.AuxCoord(
+            1, long_name='depth', units='m',
+            bounds=np.array([0. , 2]), attributes={'positive': 'down'})
+        grib = gribapi.grib_new_from_samples("GRIB2")
+        set_fixed_surfaces(cube, grib)
+        self.assertEqual(
+            gribapi.grib_get_double(grib, "scaledValueOfFirstFixedSurface"),
+            0.)
+        self.assertEqual(
+            gribapi.grib_get_double(grib, "scaledValueOfSecondFixedSurface"),
+            2)
+        self.assertEqual(
+            gribapi.grib_get_long(grib, "typeOfFirstFixedSurface"),
+            106)
+        self.assertEqual(
+            gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
+            106)
+
+
+
+        
 
 if __name__ == "__main__":
     tests.main()

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -81,7 +81,7 @@ class Test(tests.IrisGribTest):
         cube = iris.cube.Cube([0])
         cube.add_aux_coord(iris.coords.AuxCoord(
             1, long_name='depth', units='m',
-            bounds=np.array([0. , 2]), attributes={'positive': 'down'})))
+            bounds=np.array([0. , 2]), attributes={'positive': 'down'}))
         grib = gribapi.grib_new_from_samples("GRIB2")
         set_fixed_surfaces(cube, grib)
         self.assertEqual(

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -96,10 +96,6 @@ class Test(tests.IrisGribTest):
         self.assertEqual(
             gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
             106)
-
-
-
-        
 
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
Add depth variable to allow GRIB conversion of surface fields with depth coordinate, e.g. of UM fieldsfiles for soil moisture (lbuser4=8223) or soil temperature (lbuser4=8225).