### PR TITLE
Drop Python 2 Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 
 env:
   matrix:
-    - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7
 
@@ -30,22 +29,15 @@ install:
     conda config --add channels conda-forge;
     conda update --quiet conda;
     ENV_NAME='test-environment';
-    conda create --quiet -n ${ENV_NAME} python=${PYTHON_VERSION};
+    conda create --quiet -n ${ENV_NAME} python=${PYTHON_VERSION} mock filelock pep8;
     source activate ${ENV_NAME};
 
   # Customise the test environment
   # ------------------------------
   - >
-    if [[ "${PYTHON_VERSION}" == 2* ]]; then
-      export ECCODES_DEPS="python-eccodes";
-    else
-      export ECCODES_DEPS="eccodes pip";
-    fi;
-    conda install -n ${ENV_NAME} --quiet iris mock filelock pep8 ${ECCODES_DEPS};
-    if [[ "${PYTHON_VERSION}" == 3* ]]; then
-      pip install eccodes-python;
-      python -m eccodes selfcheck;
-    fi;
+    conda env update -n ${ENV_NAME} --quiet --file environment.yml;
+    # Check installation of eccodes.
+    python -m eccodes selfcheck;
 
   # Download and install iris-test-data
   # -----------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -2,4 +2,4 @@ channels:
     - conda-forge
 dependencies:
     - iris=2.*
-    - python-eccodes
+    - python-eccodes=0.9.3

--- a/environment.yml
+++ b/environment.yml
@@ -2,4 +2,4 @@ channels:
     - conda-forge
 dependencies:
     - iris=2.*
-    - python-eccodes=0.9.3
+    - python-eccodes>=0.9.1,<2


### PR DESCRIPTION
I think we should consider dropping Python 2 support. 

Due to the confusing nature of Python 2/3 support from `eccodes`/`eccodes-python`/`python-eccodes`, having Python 2 and Python 3 support means that the recipe/requirements will be horribly complicated.
We could simplify this by dropping Python 2. 
And anyway, Python 2 EoL is around the corner!! 

Dropping Python 2 support would mean we would have to make the next release a major release (iris grib 1.0) and remove all the Python 2 stuff (six etc)

Thoughts @bjlittle @pp-mo ?