### PR TITLE
Drop Python 2 support

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -10,10 +10,6 @@ See: `ECMWF GRIB API <https://software.ecmwf.int/wiki/display/GRIB/Home>`_.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 import datetime
 import math  # for fmod
 import warnings
@@ -85,7 +81,7 @@ TIME_CODES_EDITION1 = {
 unknown_string = "???"
 
 
-class GribDataProxy(object):
+class GribDataProxy:
     """A reference to the data payload of a single Grib message."""
 
     __slots__ = ('shape', 'dtype', 'path', 'offset')
@@ -119,11 +115,11 @@ class GribDataProxy(object):
         return {attr: getattr(self, attr) for attr in self.__slots__}
 
     def __setstate__(self, state):
-        for key, value in six.iteritems(state):
+        for key, value in state.items():
             setattr(self, key, value)
 
 
-class GribWrapper(object):
+class GribWrapper:
     """
     Contains a pygrib object plus some extra keys of our own.
 
@@ -856,7 +852,7 @@ def save_messages(messages, target, append=False):
 
     """
     # grib file (this bit is common to the pp and grib savers...)
-    if isinstance(target, six.string_types):
+    if isinstance(target, str):
         grib_file = open(target, "ab" if append else "wb")
     elif hasattr(target, "write"):
         if hasattr(target, "mode") and "b" not in target.mode:
@@ -871,5 +867,5 @@ def save_messages(messages, target, append=False):
             gribapi.grib_release(message)
     finally:
         # (this bit is common to the pp and grib savers...)
-        if isinstance(target, six.string_types):
+        if isinstance(target, str):
             grib_file.close()

--- a/iris_grib/_grib1_load_rules.py
+++ b/iris_grib/_grib1_load_rules.py
@@ -4,9 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Historically this was auto-generated from
 # SciTools/iris-code-generators:tools/gen_rules.py
 

--- a/iris_grib/_iris_mercator_support.py
+++ b/iris_grib/_iris_mercator_support.py
@@ -8,9 +8,6 @@ Temporary module to check for the extended Mercator class in Iris,
 which iris-grib requires for its Mercator support.
 
 """
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
 
 import distutils.version
 

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -10,7 +10,8 @@ cube metadata.
 """
 
 from argparse import Namespace
-from collections import namedtuple, Iterable, OrderedDict
+from collections import namedtuple, OrderedDict
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 import math
 import warnings

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -9,9 +9,6 @@ cube metadata.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 from argparse import Namespace
 from collections import namedtuple, Iterable, OrderedDict
 from datetime import datetime, timedelta

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -11,9 +11,6 @@ It is invoked from :meth:`iris_grib.save_grib2`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 import warnings
 
 import cf_units

--- a/iris_grib/grib_phenom_translation.py
+++ b/iris_grib/grib_phenom_translation.py
@@ -17,10 +17,6 @@ Currently supports only these ones:
 
 '''
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 import collections
 import warnings
 
@@ -40,7 +36,7 @@ class _LookupTable(dict):
 
     """
     def __init__(self, *args, **kwargs):
-        self._super = super(_LookupTable, self)
+        self._super = super()
         self._super.__init__(*args, **kwargs)
 
     def __getitem__(self, key):
@@ -101,7 +97,7 @@ def _make_grib1_cf_table():
         return (grib1_key, cf_data)
 
     # Interpret the imported Grib1-to-CF table.
-    for (grib1data, cfdata) in six.iteritems(grcf.GRIB1_LOCAL_TO_CF):
+    for (grib1data, cfdata) in grcf.GRIB1_LOCAL_TO_CF.items():
         assert grib1data.edition == 1
         association_entry = _make_grib1_cf_entry(
             table2_version=grib1data.t2version,
@@ -116,7 +112,7 @@ def _make_grib1_cf_table():
 
     # Do the same for special Grib1 codes that include an implied height level.
     for (grib1data, (cfdata, extra_dimcoord)) \
-            in six.iteritems(grcf.GRIB1_LOCAL_TO_CF_CONSTRAINED):
+            in grcf.GRIB1_LOCAL_TO_CF_CONSTRAINED.items():
         assert grib1data.edition == 1
         if extra_dimcoord.standard_name != 'height':
             raise ValueError('Got implied dimension coord of "{}", '
@@ -188,7 +184,7 @@ def _make_grib2_to_cf_table():
         return (grib2_key, cf_data)
 
     # Interpret the grib2 info from grib_cf_map
-    for grib2data, cfdata in six.iteritems(grcf.GRIB2_TO_CF):
+    for grib2data, cfdata in grcf.GRIB2_TO_CF.items():
         assert grib2data.edition == 2
         association_entry = _make_grib2_cf_entry(
             param_discipline=grib2data.discipline,
@@ -248,7 +244,7 @@ def _make_cf_to_grib2_table():
         return (cf_key, grib2_data)
 
     # Interpret the imported CF-to-Grib2 table into a lookup table
-    for cfdata, grib2data in six.iteritems(grcf.CF_TO_GRIB2):
+    for cfdata, grib2data in grcf.CF_TO_GRIB2.items():
         assert grib2data.edition == 2
         a_cf_unit = cf_units.Unit(cfdata.units)
         association_entry = _make_cf_grib2_entry(

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -8,10 +8,6 @@ Defines a lightweight wrapper class to wrap a single GRIB message.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 from collections import namedtuple
 import re
 
@@ -41,7 +37,7 @@ def _grib_get_array_wrapper(f):
     return f
 
 
-class _OpenFileRef(object):
+class _OpenFileRef:
     """
     A reference to an open file that ensures that the file is closed
     when the object is garbage collected.
@@ -54,7 +50,7 @@ class _OpenFileRef(object):
             self.open_file.close()
 
 
-class GribMessage(object):
+class GribMessage:
     """
     An in-memory representation of a GribMessage, providing
     access to the :meth:`~GribMessage.data` payload and the metadata
@@ -193,7 +189,7 @@ class _MessageLocation(namedtuple('_MessageLocation', 'filename offset')):
         return _RawGribMessage.from_file_offset(self.filename, self.offset)
 
 
-class _DataProxy(object):
+class _DataProxy:
     """A reference to the data payload of a single GRIB message."""
 
     __slots__ = ('shape', 'dtype', 'recreate_raw')
@@ -281,11 +277,11 @@ class _DataProxy(object):
         return {attr: getattr(self, attr) for attr in self.__slots__}
 
     def __setstate__(self, state):
-        for key, value in six.iteritems(state):
+        for key, value in state.items():
             setattr(self, key, value)
 
 
-class _RawGribMessage(object):
+class _RawGribMessage:
     """
     Lightweight GRIB message wrapper, containing **only** the coded keys
     of the input GRIB message.
@@ -386,7 +382,7 @@ class _RawGribMessage(object):
         return sections
 
 
-class Section(object):
+class Section:
     """
     A Section of a GRIB message, supporting dictionary like access to
     attributes using gribapi key strings.

--- a/iris_grib/tests/__init__.py
+++ b/iris_grib/tests/__init__.py
@@ -10,9 +10,6 @@ This imports iris.tests, which requires to be done before anything else for
 plot control reasons : see documentation there.
 
 """
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
 
 import iris.tests
 
@@ -46,7 +43,7 @@ class IrisGribTest(IrisTest):
         as a string, or sequence of strings.
 
         """
-        if not isinstance(relative_path, six.string_types):
+        if not isinstance(relative_path, str):
             relative_path = os.path.join(*relative_path)
         return os.path.abspath(os.path.join(_RESULT_PATH, relative_path))
 
@@ -92,6 +89,6 @@ class IrisGribTest(IrisTest):
         relative path as a string, or sequence of strings.
 
         """
-        if not isinstance(relative_path, six.string_types):
+        if not isinstance(relative_path, str):
             relative_path = os.path.join(*relative_path)
         return os.path.abspath(os.path.join(_TESTDATA_PATH, relative_path))

--- a/iris_grib/tests/integration/__init__.py
+++ b/iris_grib/tests/integration/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Integration tests for the :mod:`iris_grib` package."""
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/integration/load_convert/__init__.py
+++ b/iris_grib/tests/integration/load_convert/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Integration tests for the :mod:`iris_grib._load_convert` package."""
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/integration/load_convert/test_load_hybrid_coords.py
+++ b/iris_grib/tests/integration/load_convert/test_load_hybrid_coords.py
@@ -8,9 +8,6 @@ Integration test for loading hybrid height data.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/integration/round_trip/__init__.py
+++ b/iris_grib/tests/integration/round_trip/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Round-trip integration tests for the :mod:`iris-grib` package."""
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/integration/round_trip/test_WAFC_mapping_round_trip.py
+++ b/iris_grib/tests/integration/round_trip/test_WAFC_mapping_round_trip.py
@@ -9,9 +9,6 @@ hybrid pressure cubes.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
+++ b/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
@@ -9,9 +9,6 @@ hybrid pressure cubes.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/integration/save_rules/__init__.py
+++ b/iris_grib/tests/integration/save_rules/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Unit tests for the :mod:`iris_grib._save_rules` package."""
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/integration/save_rules/test_grid_definition_section.py
+++ b/iris_grib/tests/integration/save_rules/test_grid_definition_section.py
@@ -9,9 +9,6 @@ to confirm that the correct grid_definition_template is being selected.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
@@ -115,7 +112,7 @@ class Test(tests.IrisGribTest, GdtTestMixin):
 
         exp_name = cs.grid_mapping_name.replace('_', ' ').title()
         exp_emsg = 'not supported for coordinate system {!r}'.format(exp_name)
-        with self.assertRaisesRegexp(ValueError, exp_emsg):
+        with self.assertRaisesRegex(ValueError, exp_emsg):
             grid_definition_section(test_cube, self.mock_grib)
 
 

--- a/iris_grib/tests/integration/save_rules/test_save_hybrid_coords.py
+++ b/iris_grib/tests/integration/save_rules/test_save_hybrid_coords.py
@@ -7,8 +7,6 @@
 Unit tests for :func:`iris_grib._save_rules.data_section`.
 
 """
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
 
 # import iris_grib.tests first so that some things can be initialised before
 # importing anything else

--- a/iris_grib/tests/test_license_headers.py
+++ b/iris_grib/tests/test_license_headers.py
@@ -8,9 +8,6 @@ Unit tests for iris-grib license header conformance.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 from datetime import datetime
 from fnmatch import fnmatch
 import os

--- a/iris_grib/tests/test_pep8.py
+++ b/iris_grib/tests/test_pep8.py
@@ -8,9 +8,6 @@ Unit tests for iris-grib pep8 conformance.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 import os
 import unittest
 

--- a/iris_grib/tests/unit/__init__.py
+++ b/iris_grib/tests/unit/__init__.py
@@ -5,16 +5,13 @@
 # licensing details.
 """Unit tests for the :mod:`iris_grib` package."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 import gribapi
-import mock
 import numpy as np
+from unittest import mock
 
 import iris
 

--- a/iris_grib/tests/unit/grib1_load_rules/__init__.py
+++ b/iris_grib/tests/unit/grib1_load_rules/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Unit tests for the :mod:`iris_grib._grib1_load_rules` module."""
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
+++ b/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
@@ -5,16 +5,13 @@
 # licensing details.
 """Unit tests for :func:`iris_grib._grib1_load_rules.grib1_convert`."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else
 import iris_grib.tests as tests
 
 import cf_units
 import gribapi
-import mock
+from unittest import mock
 
 import iris
 from iris.exceptions import TranslationError
@@ -29,7 +26,7 @@ class TestBadEdition(tests.IrisGribTest):
     def test(self):
         message = mock.Mock(edition=2)
         emsg = 'GRIB edition 2 is not supported'
-        with self.assertRaisesRegexp(TranslationError, emsg):
+        with self.assertRaisesRegex(TranslationError, emsg):
             grib1_convert(message)
 
 

--- a/iris_grib/tests/unit/grib_phenom_translation/__init__.py
+++ b/iris_grib/tests/unit/grib_phenom_translation/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Unit tests for the :mod:`iris_grib.grib_phenom_translation` package."""
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/unit/grib_phenom_translation/test_grib_phenom_translation.py
+++ b/iris_grib/tests/unit/grib_phenom_translation/test_grib_phenom_translation.py
@@ -10,8 +10,6 @@ Carried over from old iris/tests/test_grib_phenom_translation.py.
 Code is out of step with current test conventions and standards.
 
 '''
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
 
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.

--- a/iris_grib/tests/unit/load_convert/__init__.py
+++ b/iris_grib/tests/unit/load_convert/__init__.py
@@ -5,9 +5,6 @@
 # licensing details.
 """Unit tests for the :mod:`iris_grib._load_convert` package."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test__hindcast_fix.py
+++ b/iris_grib/tests/unit/load_convert/test__hindcast_fix.py
@@ -8,9 +8,6 @@ Tests for function :func:`iris_grib._load_convert._hindcast_fix`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_bitmap_section.py
+++ b/iris_grib/tests/unit/load_convert/test_bitmap_section.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.bitmap_section.`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -28,7 +25,7 @@ class Test(tests.IrisGribTest):
         # different things, but load_convert treats them identically.
         message = _make_test_message({6: {'bitMapIndicator': 100,
                                           'bitmap': None}})
-        with self.assertRaisesRegexp(TranslationError, 'unsupported bitmap'):
+        with self.assertRaisesRegex(TranslationError, 'unsupported bitmap'):
             bitmap_section(message.sections[6])
 
 

--- a/iris_grib/tests/unit/load_convert/test_calculate_increment.py
+++ b/iris_grib/tests/unit/load_convert/test_calculate_increment.py
@@ -8,9 +8,6 @@ Unit tests for `iris_grib._load_convert._calculate_increment`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_convert.py
+++ b/iris_grib/tests/unit/load_convert/test_convert.py
@@ -5,14 +5,11 @@
 # licensing details.
 """Test function :func:`iris_grib._load_convert.convert`."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 from iris.exceptions import TranslationError
 
@@ -40,7 +37,7 @@ class TestGribMessage(tests.IrisGribTest):
         sections = [{'editionNumber': 1}]
         field = _make_test_message(sections)
         emsg = 'edition 1 is not supported'
-        with self.assertRaisesRegexp(TranslationError, emsg):
+        with self.assertRaisesRegex(TranslationError, emsg):
             convert(field)
 
 
@@ -49,7 +46,7 @@ class TestGribWrapper(tests.IrisGribTest):
         # Test object with no '.sections', and '.edition' ==2.
         field = mock.Mock(edition=2, spec=('edition'))
         emsg = 'edition 2 is not supported'
-        with self.assertRaisesRegexp(TranslationError, emsg):
+        with self.assertRaisesRegex(TranslationError, emsg):
             convert(field)
 
     def test_edition_1(self):

--- a/iris_grib/tests/unit/load_convert/test_data_cutoff.py
+++ b/iris_grib/tests/unit/load_convert/test_data_cutoff.py
@@ -8,14 +8,11 @@ Tests for function :func:`iris_grib._load_convert.data_cutoff`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 from iris_grib._load_convert import _MDI as MDI
 from iris_grib._load_convert import data_cutoff

--- a/iris_grib/tests/unit/load_convert/test_ellipsoid.py
+++ b/iris_grib/tests/unit/load_convert/test_ellipsoid.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.ellipsoid.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -34,7 +31,7 @@ class Test(tests.IrisGribTest):
         unsupported = [8, 9, 10, MDI]
         emsg = 'unsupported shape of the earth'
         for shape in unsupported:
-            with self.assertRaisesRegexp(TranslationError, emsg):
+            with self.assertRaisesRegex(TranslationError, emsg):
                 ellipsoid(shape, MDI, MDI, MDI)
 
     def test_spherical_default_supported(self):
@@ -47,7 +44,7 @@ class Test(tests.IrisGribTest):
     def test_spherical_shape_1_no_radius(self):
         shape = 1
         emsg = 'radius to be specified'
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with self.assertRaisesRegex(ValueError, emsg):
             ellipsoid(shape, MDI, MDI, MDI)
 
     def test_spherical_shape_1(self):
@@ -60,19 +57,19 @@ class Test(tests.IrisGribTest):
     def test_oblate_shape_3_7_no_axes(self):
         for shape in [3, 7]:
             emsg = 'axis to be specified'
-            with self.assertRaisesRegexp(ValueError, emsg):
+            with self.assertRaisesRegex(ValueError, emsg):
                 ellipsoid(shape, MDI, MDI, MDI)
 
     def test_oblate_shape_3_7_no_major(self):
         for shape in [3, 7]:
             emsg = 'major axis to be specified'
-            with self.assertRaisesRegexp(ValueError, emsg):
+            with self.assertRaisesRegex(ValueError, emsg):
                 ellipsoid(shape, MDI, 1, MDI)
 
     def test_oblate_shape_3_7_no_minor(self):
         for shape in [3, 7]:
             emsg = 'minor axis to be specified'
-            with self.assertRaisesRegexp(ValueError, emsg):
+            with self.assertRaisesRegex(ValueError, emsg):
                 ellipsoid(shape, 1, MDI, MDI)
 
     def test_oblate_shape_3_7(self):

--- a/iris_grib/tests/unit/load_convert/test_ellipsoid_geometry.py
+++ b/iris_grib/tests/unit/load_convert/test_ellipsoid_geometry.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.ellipsoid_geometry.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_ensemble_identifier.py
+++ b/iris_grib/tests/unit/load_convert/test_ensemble_identifier.py
@@ -9,15 +9,12 @@ Test function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
+from unittest import mock
 import warnings
 
 from iris.coords import DimCoord

--- a/iris_grib/tests/unit/load_convert/test_fixup_float32_from_int32.py
+++ b/iris_grib/tests/unit/load_convert/test_fixup_float32_from_int32.py
@@ -8,9 +8,6 @@ Unit tests for `iris_grib._load_convert.fixup_float32_from_int32`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_fixup_int32_from_uint32.py
+++ b/iris_grib/tests/unit/load_convert/test_fixup_int32_from_uint32.py
@@ -8,9 +8,6 @@ Unit tests for `iris_grib._load_convert.fixup_int32_from_uint32`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_forecast_period_coord.py
+++ b/iris_grib/tests/unit/load_convert/test_forecast_period_coord.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.forecast_period_coord.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_generating_process.py
+++ b/iris_grib/tests/unit/load_convert/test_generating_process.py
@@ -9,9 +9,6 @@ Tests for function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_grib2_convert.py
+++ b/iris_grib/tests/unit/load_convert/test_grib2_convert.py
@@ -5,15 +5,12 @@
 # licensing details.
 """Test function :func:`iris_grib._load_convert.grib2_convert`."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 import copy
-import mock
+from unittest import mock
 
 import iris_grib
 from iris_grib._load_convert import grib2_convert

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_0_and_1.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_0_and_1.py
@@ -9,9 +9,6 @@ Test function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -124,7 +121,7 @@ class Test(tests.IrisGribTest):
         section = {'numberOfOctectsForNumberOfPoints': 1}
         cs = None
         metadata = None
-        with self.assertRaisesRegexp(TranslationError, 'quasi-regular'):
+        with self.assertRaisesRegex(TranslationError, 'quasi-regular'):
             grid_definition_template_0_and_1(section,
                                              metadata,
                                              'latitude',
@@ -136,7 +133,7 @@ class Test(tests.IrisGribTest):
                    'interpretationOfNumberOfPoints': 1}
         cs = None
         metadata = None
-        with self.assertRaisesRegexp(TranslationError, 'quasi-regular'):
+        with self.assertRaisesRegex(TranslationError, 'quasi-regular'):
             grid_definition_template_0_and_1(section,
                                              metadata,
                                              'latitude',

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_10.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_10.py
@@ -9,9 +9,6 @@ Unit tests for
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_12.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_12.py
@@ -9,9 +9,6 @@ Unit tests for
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -99,16 +96,16 @@ class Test(tests.IrisGribTest):
         section = self.section_3()
         section['scanningMode'] = 0b11000000
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError,
-                                     '-x scanning'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError,
+                                    '-x scanning'):
             grid_definition_template_12(section, metadata)
 
     def test_negative_y(self):
         section = self.section_3()
         section['scanningMode'] = 0b00000000
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError,
-                                     '-y scanning'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError,
+                                    '-y scanning'):
             grid_definition_template_12(section, metadata)
 
     def test_transposed(self):
@@ -135,8 +132,8 @@ class Test(tests.IrisGribTest):
         section = self.section_3()
         section['X2'] += 100
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError,
-                                     'grid'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError,
+                                    'grid'):
             grid_definition_template_12(section, metadata)
 
     def test_scale_workaround(self):

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_20.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_20.py
@@ -8,9 +8,6 @@ Unit tests for
 :func:`iris_grib._load_convert.grid_definition_template_20`.
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_30.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_30.py
@@ -8,9 +8,6 @@ Unit tests for
 :func:`iris_grib._load_convert.grid_definition_template_30`.
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_40.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_40.py
@@ -9,9 +9,6 @@ Unit tests for
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_4_and_5.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_4_and_5.py
@@ -9,19 +9,16 @@ Test function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
-import numpy as np
+from unittest import mock
 import warnings
 
 from iris.coords import DimCoord
+import numpy as np
 
 from iris_grib._load_convert import (grid_definition_template_4_and_5,
                                      _MDI as MDI)

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_5.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_5.py
@@ -9,15 +9,12 @@ Test function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
+from unittest import mock
 
 from iris_grib._load_convert import grid_definition_template_5
 

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_90.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_90.py
@@ -9,10 +9,6 @@ Unit tests for
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -117,7 +113,7 @@ class Test(tests.IrisGribTest):
             self.assertEqual(result_coord, expected_coord)
 
         # Ensure no other metadata was created.
-        for name in six.iterkeys(expected):
+        for name in expected.keys():
             if name == 'dim_coords_and_dims':
                 continue
             self.assertEqual(metadata[name], expected[name])
@@ -141,46 +137,46 @@ class Test(tests.IrisGribTest):
         section = self.uk()
         section['latitudeOfSubSatellitePoint'] = 1
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError,
-                                     'non-zero latitude'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError,
+                                    'non-zero latitude'):
             grid_definition_template_90(section, metadata)
 
     def test_rotated_meridian(self):
         section = self.uk()
         section['orientationOfTheGrid'] = 1
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError,
-                                     'orientation'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError,
+                                    'orientation'):
             grid_definition_template_90(section, metadata)
 
     def test_zero_height(self):
         section = self.uk()
         section['Nr'] = 0
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError,
-                                     'zero'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError,
+                                    'zero'):
             grid_definition_template_90(section, metadata)
 
     def test_orthographic(self):
         section = self.uk()
         section['Nr'] = MDI
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError,
-                                     'orthographic'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError,
+                                    'orthographic'):
             grid_definition_template_90(section, metadata)
 
     def test_scanning_mode_positive_x(self):
         section = self.uk()
         section['scanningMode'] = 0b01000000
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError, r'\+x'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError, r'\+x'):
             grid_definition_template_90(section, metadata)
 
     def test_scanning_mode_negative_y(self):
         section = self.uk()
         section['scanningMode'] = 0b10000000
         metadata = empty_metadata()
-        with self.assertRaisesRegexp(iris.exceptions.TranslationError, '-y'):
+        with self.assertRaisesRegex(iris.exceptions.TranslationError, '-y'):
             grid_definition_template_90(section, metadata)
 
 

--- a/iris_grib/tests/unit/load_convert/test_other_time_coord.py
+++ b/iris_grib/tests/unit/load_convert/test_other_time_coord.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.other_time_coord.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -43,7 +40,7 @@ class TestInvalid(tests.IrisGribTest):
         rt = iris.coords.DimCoord(48, 'time', units='hours since epoch',
                                   bounds=[36, 60])
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'bounds'):
+        with self.assertRaisesRegex(ValueError, 'bounds'):
             other_time_coord(rt, fp)
 
     def test_frt_with_bounds(self):
@@ -51,58 +48,58 @@ class TestInvalid(tests.IrisGribTest):
                                   units='hours since epoch',
                                   bounds=[42, 54])
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'bounds'):
+        with self.assertRaisesRegex(ValueError, 'bounds'):
             other_time_coord(rt, fp)
 
     def test_fp_with_bounds(self):
         rt = iris.coords.DimCoord(48, 'time', units='hours since epoch')
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours',
                                   bounds=[3, 9])
-        with self.assertRaisesRegexp(ValueError, 'bounds'):
+        with self.assertRaisesRegex(ValueError, 'bounds'):
             other_time_coord(rt, fp)
 
     def test_vector_t(self):
         rt = iris.coords.DimCoord([0, 3], 'time', units='hours since epoch')
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'Vector'):
+        with self.assertRaisesRegex(ValueError, 'Vector'):
             other_time_coord(rt, fp)
 
     def test_vector_frt(self):
         rt = iris.coords.DimCoord([0, 3], 'forecast_reference_time',
                                   units='hours since epoch')
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'Vector'):
+        with self.assertRaisesRegex(ValueError, 'Vector'):
             other_time_coord(rt, fp)
 
     def test_vector_fp(self):
         rt = iris.coords.DimCoord(48, 'time', units='hours since epoch')
         fp = iris.coords.DimCoord([6, 12], 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'Vector'):
+        with self.assertRaisesRegex(ValueError, 'Vector'):
             other_time_coord(rt, fp)
 
     def test_invalid_rt_name(self):
         rt = iris.coords.DimCoord(1, 'height')
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'reference time'):
+        with self.assertRaisesRegex(ValueError, 'reference time'):
             other_time_coord(rt, fp)
 
     def test_invalid_t_unit(self):
         rt = iris.coords.DimCoord(1, 'time', units='Pa')
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'unit.*Pa'):
+        with self.assertRaisesRegex(ValueError, 'unit.*Pa'):
             other_time_coord(rt, fp)
 
     def test_invalid_frt_unit(self):
         rt = iris.coords.DimCoord(1, 'forecast_reference_time', units='km')
         fp = iris.coords.DimCoord(6, 'forecast_period', units='hours')
-        with self.assertRaisesRegexp(ValueError, 'unit.*km'):
+        with self.assertRaisesRegex(ValueError, 'unit.*km'):
             other_time_coord(rt, fp)
 
     def test_invalid_fp_unit(self):
         rt = iris.coords.DimCoord(48, 'forecast_reference_time',
                                   units='hours since epoch')
         fp = iris.coords.DimCoord(6, 'forecast_period', units='kg')
-        with self.assertRaisesRegexp(ValueError, 'unit.*kg'):
+        with self.assertRaisesRegex(ValueError, 'unit.*kg'):
             other_time_coord(rt, fp)
 
 

--- a/iris_grib/tests/unit/load_convert/test_product_definition_section.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_section.py
@@ -8,17 +8,14 @@ Tests for `iris_grib._load_convert.product_definition_section`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-from iris.coords import DimCoord
-import mock
-import six
-
 from itertools import product
+from unittest import mock
+
+from iris.coords import DimCoord
 
 from iris_grib._load_convert import product_definition_section
 from iris_grib.tests.unit.load_convert import empty_metadata
@@ -87,7 +84,7 @@ class TestFixedSurfaces(tests.IrisGribTest):
         if fs_is_expected and not fs_is_present:
             # Should error since the expected keys are missing.
             error_message = 'FixedSurface'
-            with six.assertRaisesRegex(self, KeyError, error_message):
+            with self.assertRaisesRegex(KeyError, error_message):
                 run_function()
         else:
             # Should have a successful run for all other circumstances.

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_0.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_0.py
@@ -9,14 +9,11 @@ Test function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 import iris.coords
 

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_1.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_1.py
@@ -9,15 +9,12 @@ Test function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
+from unittest import mock
 import warnings
 
 from iris.coords import DimCoord

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_10.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_10.py
@@ -8,15 +8,12 @@ Test function :func:`iris_grib._load_convert.product_definition_template_10`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
+from unittest import mock
 
 from iris.coords import DimCoord
 from iris_grib._load_convert import product_definition_template_10

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_11.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_11.py
@@ -8,15 +8,12 @@ Test function :func:`iris_grib._load_convert.product_definition_template_11`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
+from unittest import mock
 import warnings
 
 from iris.coords import DimCoord, CellMethod

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_15.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_15.py
@@ -12,14 +12,11 @@ testing for the statistical method and spatial-processing type.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 import iris.coords
 from iris.exceptions import TranslationError
@@ -94,14 +91,14 @@ class Test(LoadConvertTest):
         section = section_4_sample()
         section['statisticalProcess'] = 999
         msg = 'unsupported statistical process type \[999\]'
-        with self.assertRaisesRegexp(TranslationError, msg):
+        with self.assertRaisesRegex(TranslationError, msg):
             self._translate(section)
 
     def test_bad_spatial_processing_code(self):
         section = section_4_sample()
         section['spatialProcessing'] = 999
         msg = 'unsupported spatial processing type \[999\]'
-        with self.assertRaisesRegexp(TranslationError, msg):
+        with self.assertRaisesRegex(TranslationError, msg):
             self._translate(section)
 
 

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_31.py
@@ -8,19 +8,17 @@ Tests for `iris_grib._load_convert.product_definition_template_31`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
-import numpy as np
+from unittest import mock
 import warnings
 
 from iris.coords import AuxCoord
+import numpy as np
+
 from iris_grib.tests.unit.load_convert import empty_metadata
 
 from iris_grib._load_convert import product_definition_template_31

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_32.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_32.py
@@ -8,19 +8,17 @@ Tests for `iris_grib._load_convert.product_definition_template_32`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
-import numpy as np
+from unittest import mock
 import warnings
 
 from iris.coords import AuxCoord, DimCoord
+import numpy as np
+
 from iris_grib.tests.unit.load_convert import empty_metadata
 from iris_grib._load_convert import _MDI as MDI
 

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_40.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_40.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.product_definition_template_40`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_8.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_8.py
@@ -9,15 +9,11 @@ Tests for function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 from iris_grib._load_convert import product_definition_template_8
 
@@ -62,10 +58,10 @@ class Test(tests.IrisGribTest):
                          ['aux_coords_and_dims', 'cell_methods'])
         self.assertEqual(self.metadata['cell_methods'],
                          [mock.sentinel.dummy_cell_method])
-        six.assertCountEqual(self, self.metadata['aux_coords_and_dims'],
-                             [(self.frt_coord, None),
-                              (mock.sentinel.dummy_fp_coord, None),
-                              (mock.sentinel.dummy_time_coord, None)])
+        self.assertCountEqual(self.metadata['aux_coords_and_dims'],
+                              [(self.frt_coord, None),
+                               (mock.sentinel.dummy_fp_coord, None),
+                               (mock.sentinel.dummy_time_coord, None)])
 
 
 if __name__ == '__main__':

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_9.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_9.py
@@ -9,14 +9,11 @@ Tests for function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 from iris.exceptions import TranslationError
 
@@ -54,22 +51,22 @@ class Test(tests.IrisGribTest):
 
     def test_fail_bad_probability_type(self):
         self.section['probabilityType'] = 17
-        with self.assertRaisesRegexp(TranslationError,
-                                     'unsupported probability type'):
+        with self.assertRaisesRegex(TranslationError,
+                                    'unsupported probability type'):
             product_definition_template_9(
                 self.section, self.metadata, self.frt_coord)
 
     def test_fail_bad_threshold_value(self):
         self.section['scaledValueOfUpperLimit'] = _MDI
-        with self.assertRaisesRegexp(TranslationError,
-                                     'missing scaled value'):
+        with self.assertRaisesRegex(TranslationError,
+                                    'missing scaled value'):
             product_definition_template_9(
                 self.section, self.metadata, self.frt_coord)
 
     def test_fail_bad_threshold_scalefactor(self):
         self.section['scaleFactorOfUpperLimit'] = _MDI
-        with self.assertRaisesRegexp(TranslationError,
-                                     'missing scale factor'):
+        with self.assertRaisesRegex(TranslationError,
+                                    'missing scale factor'):
             product_definition_template_9(
                 self.section, self.metadata, self.frt_coord)
 

--- a/iris_grib/tests/unit/load_convert/test_projection_centre.py
+++ b/iris_grib/tests/unit/load_convert/test_projection_centre.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.projection centre.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_reference_time_coord.py
+++ b/iris_grib/tests/unit/load_convert/test_reference_time_coord.py
@@ -10,9 +10,6 @@ Reference Code Table 1.2.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -68,7 +65,7 @@ class Test(tests.IrisGribTest):
         section = deepcopy(self.section)
         section['significanceOfReferenceTime'] = 5
         emsg = 'unsupported significance'
-        with self.assertRaisesRegexp(TranslationError, emsg):
+        with self.assertRaisesRegex(TranslationError, emsg):
             self._check(section)
 
 

--- a/iris_grib/tests/unit/load_convert/test_resolution_flags.py
+++ b/iris_grib/tests/unit/load_convert/test_resolution_flags.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.resolution_flags.`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_satellite_common.py
+++ b/iris_grib/tests/unit/load_convert/test_satellite_common.py
@@ -8,19 +8,17 @@ Tests for `iris_grib._load_convert.satellite_common`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
-import numpy as np
+from unittest import mock
 import warnings
 
 from iris.coords import AuxCoord
+import numpy as np
+
 from iris_grib.tests.unit.load_convert import empty_metadata
 
 from iris_grib._load_convert import satellite_common

--- a/iris_grib/tests/unit/load_convert/test_scanning_mode.py
+++ b/iris_grib/tests/unit/load_convert/test_scanning_mode.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.scanning_mode.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_statistical_cell_method.py
+++ b/iris_grib/tests/unit/load_convert/test_statistical_cell_method.py
@@ -9,9 +9,6 @@ Tests for function
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -57,26 +54,26 @@ class Test(tests.IrisGribTest):
 
     def test_fail_bad_ranges(self):
         self.section['numberOfTimeRange'] = 0
-        with self.assertRaisesRegexp(TranslationError,
-                                     'aggregation over "0 time ranges"'):
+        with self.assertRaisesRegex(TranslationError,
+                                    'aggregation over "0 time ranges"'):
             statistical_cell_method(self.section)
 
     def test_fail_multiple_ranges(self):
         self.section['numberOfTimeRange'] = 2
-        with self.assertRaisesRegexp(TranslationError,
-                                     'multiple time ranges \[2\]'):
+        with self.assertRaisesRegex(TranslationError,
+                                    'multiple time ranges \[2\]'):
             statistical_cell_method(self.section)
 
     def test_fail_unknown_statistic(self):
         self.section['typeOfStatisticalProcessing'] = 17
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TranslationError,
                 'contains an unsupported statistical process type \[17\]'):
             statistical_cell_method(self.section)
 
     def test_fail_bad_increment_type(self):
         self.section['typeOfTimeIncrement'] = 7
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TranslationError,
                 'time-increment type \[7\] is not supported'):
             statistical_cell_method(self.section)
@@ -112,7 +109,7 @@ class Test(tests.IrisGribTest):
         # Rejects PDTs other than the ones tested above.
         self.section['productDefinitionTemplateNumber'] = 101
         msg = "can't get statistical method for unsupported pdt : 4.101"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             statistical_cell_method(self.section)
 
 

--- a/iris_grib/tests/unit/load_convert/test_statistical_forecast_period_coord.py
+++ b/iris_grib/tests/unit/load_convert/test_statistical_forecast_period_coord.py
@@ -8,15 +8,12 @@ Tests for function :func:`iris_grib._load_convert.statistical_forecast_period`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 import datetime
-import mock
+from unittest import mock
 
 from iris_grib._load_convert import statistical_forecast_period_coord
 

--- a/iris_grib/tests/unit/load_convert/test_time_range_unit.py
+++ b/iris_grib/tests/unit/load_convert/test_time_range_unit.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.time_range_unit.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
@@ -38,7 +35,7 @@ class Test(tests.IrisGribTest):
 
     def test_bad_indicator(self):
         emsg = 'unsupported time range'
-        with self.assertRaisesRegexp(TranslationError, emsg):
+        with self.assertRaisesRegex(TranslationError, emsg):
             time_range_unit(-1)
 
 

--- a/iris_grib/tests/unit/load_convert/test_translate_phenomenon.py
+++ b/iris_grib/tests/unit/load_convert/test_translate_phenomenon.py
@@ -8,9 +8,6 @@ Tests for function :func:`iris_grib._load_convert.translate_phenomenon`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_unscale.py
+++ b/iris_grib/tests/unit/load_convert/test_unscale.py
@@ -8,9 +8,6 @@ Test function :func:`iris_grib._load_convert.unscale.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/load_convert/test_validity_time_coord.py
+++ b/iris_grib/tests/unit/load_convert/test_validity_time_coord.py
@@ -8,18 +8,15 @@ Test function :func:`iris_grib._load_convert.validity_time_coord.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
-from cf_units import Unit
-import mock
-import numpy as np
+from unittest import mock
 
+from cf_units import Unit
 from iris.coords import DimCoord
+import numpy as np
 
 from iris_grib._load_convert import validity_time_coord
 
@@ -36,14 +33,14 @@ class Test(tests.IrisGribTest):
         frt = mock.Mock(shape=(2,))
         fp = mock.Mock(shape=(1,))
         emsg = 'scalar forecast reference time'
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with self.assertRaisesRegex(ValueError, emsg):
             validity_time_coord(frt, fp)
 
     def test_fp_shape(self):
         frt = mock.Mock(shape=(1,))
         fp = mock.Mock(shape=(2,))
         emsg = 'scalar forecast period'
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with self.assertRaisesRegex(ValueError, emsg):
             validity_time_coord(frt, fp)
 
     def test(self):

--- a/iris_grib/tests/unit/load_convert/test_vertical_coords.py
+++ b/iris_grib/tests/unit/load_convert/test_vertical_coords.py
@@ -8,15 +8,12 @@ Test function :func:`iris_grib._load_convert.vertical_coords`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests
 
 from copy import deepcopy
-import mock
+from unittest import mock
 
 from iris.coords import DimCoord
 from iris.exceptions import TranslationError
@@ -115,7 +112,7 @@ class Test(tests.IrisGribTest):
                    'scaleFactorOfFirstFixedSurface': None,
                    'typeOfSecondFixedSurface': 0}
         emsg = 'different types of first and second fixed surface'
-        with self.assertRaisesRegexp(TranslationError, emsg):
+        with self.assertRaisesRegex(TranslationError, emsg):
             vertical_coords(section, None)
 
     def test_same_fixed_surfaces_missing_second_scaled_value(self):
@@ -126,7 +123,7 @@ class Test(tests.IrisGribTest):
                    'typeOfSecondFixedSurface': 100,
                    'scaledValueOfSecondFixedSurface': MISSING_LEVEL}
         emsg = 'missing scaled value of second fixed surface'
-        with self.assertRaisesRegexp(TranslationError, emsg):
+        with self.assertRaisesRegex(TranslationError, emsg):
             vertical_coords(section, None)
 
     def test_pressure_with_second_fixed_surface(self):

--- a/iris_grib/tests/unit/message/__init__.py
+++ b/iris_grib/tests/unit/message/__init__.py
@@ -4,6 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Unit tests for the :mod:`iris_grib.message` package."""
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa

--- a/iris_grib/tests/unit/message/test_GribMessage.py
+++ b/iris_grib/tests/unit/message/test_GribMessage.py
@@ -8,17 +8,13 @@ Unit tests for the `iris_grib.message.GribMessage` class.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
 from abc import ABCMeta, abstractmethod
+from unittest import mock
 
-import mock
 import numpy as np
 import numpy.ma as ma
 
@@ -44,11 +40,9 @@ class Test_messages_from_filename(tests.IrisGribTest):
         filename = tests.get_data_path(('GRIB', '3_layer_viz',
                                         '3_layer.grib2'))
         my_file = open(filename)
-        if six.PY2:
-            self.patch('__builtin__.open', mock.Mock(return_value=my_file))
-        else:
-            import builtins
-            self.patch('builtins.open', mock.Mock(return_value=my_file))
+
+        import builtins
+        self.patch('builtins.open', mock.Mock(return_value=my_file))
 
         messages = list(GribMessage.messages_from_filename(filename))
         self.assertFalse(my_file.closed)
@@ -109,7 +103,7 @@ class Test_data__masked(tests.IrisGribTest):
                                       6: {'bitMapIndicator': 0,
                                           'bitmap': self.bitmap},
                                       7: {'codedValues': values}})
-        with self.assertRaisesRegexp(TranslationError, 'do not match'):
+        with self.assertRaisesRegex(TranslationError, 'do not match'):
             as_concrete_data(message.data)
 
     def test_bitmap__invalid_indicator(self):
@@ -118,7 +112,7 @@ class Test_data__masked(tests.IrisGribTest):
                                       6: {'bitMapIndicator': 100,
                                           'bitmap': None},
                                       7: {'codedValues': values}})
-        with self.assertRaisesRegexp(TranslationError, 'unsupported bitmap'):
+        with self.assertRaisesRegex(TranslationError, 'unsupported bitmap'):
             as_concrete_data(message.data)
 
 
@@ -126,7 +120,7 @@ class Test_data__unsupported(tests.IrisGribTest):
     def test_unsupported_grid_definition(self):
         message = _make_test_message({3: {'sourceOfGridDefinition': 1},
                                       6: SECTION_6_NO_BITMAP})
-        with self.assertRaisesRegexp(TranslationError, 'source'):
+        with self.assertRaisesRegex(TranslationError, 'source'):
             message.data
 
     def test_unsupported_quasi_regular__number_of_octets(self):
@@ -135,7 +129,7 @@ class Test_data__unsupported(tests.IrisGribTest):
                  'numberOfOctectsForNumberOfPoints': 1,
                  'gridDefinitionTemplateNumber': 0},
              6: SECTION_6_NO_BITMAP})
-        with self.assertRaisesRegexp(TranslationError, 'quasi-regular'):
+        with self.assertRaisesRegex(TranslationError, 'quasi-regular'):
             message.data
 
     def test_unsupported_quasi_regular__interpretation(self):
@@ -145,7 +139,7 @@ class Test_data__unsupported(tests.IrisGribTest):
                  'interpretationOfNumberOfPoints': 1,
                  'gridDefinitionTemplateNumber': 0},
              6: SECTION_6_NO_BITMAP})
-        with self.assertRaisesRegexp(TranslationError, 'quasi-regular'):
+        with self.assertRaisesRegex(TranslationError, 'quasi-regular'):
             message.data
 
     def test_unsupported_template(self):
@@ -154,13 +148,13 @@ class Test_data__unsupported(tests.IrisGribTest):
                  'numberOfOctectsForNumberOfPoints': 0,
                  'interpretationOfNumberOfPoints': 0,
                  'gridDefinitionTemplateNumber': 2}})
-        with self.assertRaisesRegexp(TranslationError, 'template'):
+        with self.assertRaisesRegex(TranslationError, 'template'):
             message.data
 
 
 # Abstract, mix-in class for testing the `data` attribute for various
 # grid definition templates.
-class Mixin_data__grid_template(six.with_metaclass(ABCMeta, object)):
+class Mixin_data__grid_template(metaclass=ABCMeta):
     @abstractmethod
     def section_3(self, scanning_mode):
         raise NotImplementedError()
@@ -169,7 +163,7 @@ class Mixin_data__grid_template(six.with_metaclass(ABCMeta, object)):
         message = _make_test_message(
             {3: self.section_3(1),
              6: SECTION_6_NO_BITMAP})
-        with self.assertRaisesRegexp(TranslationError, 'scanning mode'):
+        with self.assertRaisesRegex(TranslationError, 'scanning mode'):
             message.data
 
     def _test(self, scanning_mode):
@@ -267,8 +261,8 @@ class Test_data__unknown_grid_template(tests.IrisGribTest):
             {3: _example_section_3(999, 0),
              6: SECTION_6_NO_BITMAP,
              7: {'codedValues': np.arange(12)}})
-        with self.assertRaisesRegexp(TranslationError,
-                                     'template 999 is not supported'):
+        with self.assertRaisesRegex(TranslationError,
+                                    'template 999 is not supported'):
             data = message.data
 
 

--- a/iris_grib/tests/unit/message/test_Section.py
+++ b/iris_grib/tests/unit/message/test_Section.py
@@ -8,9 +8,6 @@ Unit tests for `iris_grib.message.Section`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
@@ -50,7 +47,7 @@ class Test___getitem__(tests.IrisGribTest):
 
     def test_invalid(self):
         section = Section(self.grib_id, None, ['Ni'])
-        with self.assertRaisesRegexp(KeyError, 'Nii'):
+        with self.assertRaisesRegex(KeyError, 'Nii'):
             section['Nii']
 
 

--- a/iris_grib/tests/unit/message/test__DataProxy.py
+++ b/iris_grib/tests/unit/message/test__DataProxy.py
@@ -8,9 +8,6 @@ Unit tests for the `iris.message._DataProxy` class.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
@@ -40,7 +37,7 @@ class Test__bitmap(tests.IrisGribTest):
     def test_bitmap__invalid_indicator(self):
         section_6 = {'bitMapIndicator': 100, 'bitmap': None}
         data_proxy = _DataProxy(0, 0, 0)
-        with self.assertRaisesRegexp(TranslationError, 'unsupported bitmap'):
+        with self.assertRaisesRegex(TranslationError, 'unsupported bitmap'):
             data_proxy._bitmap(section_6)
 
 

--- a/iris_grib/tests/unit/message/test__MessageLocation.py
+++ b/iris_grib/tests/unit/message/test__MessageLocation.py
@@ -8,14 +8,11 @@ Unit tests for the `iris.message._MessageLocation` class.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 from iris_grib.message import _MessageLocation
 

--- a/iris_grib/tests/unit/message/test__RawGribMessage.py
+++ b/iris_grib/tests/unit/message/test__RawGribMessage.py
@@ -8,9 +8,6 @@ Unit tests for the `iris_grib.message._RawGribMessage` class.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/__init__.py
+++ b/iris_grib/tests/unit/save_rules/__init__.py
@@ -5,14 +5,12 @@
 # licensing details.
 """Unit tests for the :mod:`iris_grib.grib_save_rules` module."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
+
 import numpy as np
 
 from iris.coords import DimCoord
@@ -21,7 +19,7 @@ from iris.cube import Cube
 from iris.fileformats.pp import EARTH_RADIUS as PP_DEFAULT_EARTH_RADIUS
 
 
-class GdtTestMixin(object):
+class GdtTestMixin:
     """Some handy common test capabilities for grib grid-definition tests."""
     TARGET_MODULE = 'iris_grib._save_rules'
 

--- a/iris_grib/tests/unit/save_rules/test__missing_forecast_period.py
+++ b/iris_grib/tests/unit/save_rules/test__missing_forecast_period.py
@@ -8,9 +8,6 @@ Unit tests for :func:`iris_grib._save_rules._missing_forecast_period.`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test__non_missing_forecast_period.py
+++ b/iris_grib/tests/unit/save_rules/test__non_missing_forecast_period.py
@@ -5,9 +5,6 @@
 # licensing details.
 """Unit tests for module-level functions."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test__product_definition_template_8_10_and_11.py
+++ b/iris_grib/tests/unit/save_rules/test__product_definition_template_8_10_and_11.py
@@ -9,16 +9,14 @@ Unit tests for
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock
@@ -61,8 +59,8 @@ class TestTypeOfStatisticalProcessing(tests.IrisGribTest):
         cell_method = CellMethod(method='sum',
                                  coords=['time', 'forecast_period'])
         cube.add_cell_method(cell_method)
-        with self.assertRaisesRegexp(ValueError,
-                                     'Cannot handle multiple coordinate name'):
+        with self.assertRaisesRegex(ValueError,
+                                    'Cannot handle multiple coordinate name'):
             _product_definition_template_8_10_and_11(cube, mock.sentinel.grib)
 
     @mock.patch.object(gribapi, 'grib_set')
@@ -70,7 +68,7 @@ class TestTypeOfStatisticalProcessing(tests.IrisGribTest):
         cube = self.cube
         cell_method = CellMethod(method='mean', coords=['season'])
         cube.add_cell_method(cell_method)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, "Expected a cell method with a coordinate "
                 "name of 'time'"):
             _product_definition_template_8_10_and_11(cube, mock.sentinel.grib)
@@ -89,7 +87,7 @@ class TestTimeCoordPrerequisites(tests.IrisGribTest):
                          bounds=[[22, 23], [23, 24], [24, 25]],
                          units=Unit('days since epoch', calendar='standard'))
         self.cube.add_aux_coord(coord, 0)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Expected length one time coordinate'):
             _product_definition_template_8_10_and_11(self.cube,
                                                      mock.sentinel.grib)
@@ -100,7 +98,7 @@ class TestTimeCoordPrerequisites(tests.IrisGribTest):
         coord = DimCoord(23, 'time',
                          units=Unit('days since epoch', calendar='standard'))
         self.cube.add_aux_coord(coord)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Expected time coordinate with two bounds, '
                 'got 0 bounds'):
             _product_definition_template_8_10_and_11(self.cube,
@@ -112,7 +110,7 @@ class TestTimeCoordPrerequisites(tests.IrisGribTest):
         coord = DimCoord(23, 'time', bounds=[21, 22, 23],
                          units=Unit('days since epoch', calendar='standard'))
         self.cube.add_aux_coord(coord)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Expected time coordinate with two bounds, '
                 'got 3 bounds'):
             _product_definition_template_8_10_and_11(self.cube,

--- a/iris_grib/tests/unit/save_rules/test_data_section.py
+++ b/iris_grib/tests/unit/save_rules/test_data_section.py
@@ -8,17 +8,14 @@ Unit tests for :func:`iris_grib._save_rules.data_section`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # import iris_grib.tests first so that some things can be initialised before
 # importing anything else
 import iris_grib.tests as tests
 
-import mock
-import numpy as np
+from unittest import mock
 
 import iris.cube
+import numpy as np
 
 from iris_grib._save_rules import data_section
 

--- a/iris_grib/tests/unit/save_rules/test_fixup_float32_as_int32.py
+++ b/iris_grib/tests/unit/save_rules/test_fixup_float32_as_int32.py
@@ -8,9 +8,6 @@ Unit tests for `iris_grib._save_rules.fixup_float32_as_int32`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_fixup_int32_as_uint32.py
+++ b/iris_grib/tests/unit/save_rules/test_fixup_int32_as_uint32.py
@@ -8,9 +8,6 @@ Unit tests for `iris_grib._save_rules.fixup_int32_as_uint32`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_0.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_0.py
@@ -8,9 +8,6 @@ Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_0`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_1.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_1.py
@@ -8,9 +8,6 @@ Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_1`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
@@ -110,7 +107,7 @@ class Test(tests.IrisGribTest, GdtTestMixin):
                            north_pole_grid_longitude=22.5,
                            ellipsoid=self.default_ellipsoid)
         test_cube = self._make_test_cube(cs=cs)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TranslationError,
                 'not yet support .* rotated prime meridian.'):
             grid_definition_template_1(test_cube, self.mock_grib)

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_10.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_10.py
@@ -8,9 +8,6 @@ Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_10`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_12.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_12.py
@@ -8,9 +8,6 @@ Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_12`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_30.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_30.py
@@ -8,9 +8,6 @@ Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_30`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_4.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_4.py
@@ -8,9 +8,6 @@ Unit tests for :func:`iris_grib._save_rules.grid_definition_template_4`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_5.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_5.py
@@ -8,9 +8,6 @@ Unit tests for :meth:`iris_grib._save_rules.grid_definition_template_5`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
@@ -102,7 +99,7 @@ class Test(tests.IrisGribTest, GdtTestMixin):
                            north_pole_grid_longitude=22.5,
                            ellipsoid=self.default_ellipsoid)
         test_cube = self._make_test_cube(cs=cs)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TranslationError,
                 'not yet support .* rotated prime meridian.'):
             grid_definition_template_5(test_cube, self.mock_grib)

--- a/iris_grib/tests/unit/save_rules/test_identification.py
+++ b/iris_grib/tests/unit/save_rules/test_identification.py
@@ -5,15 +5,13 @@
 # licensing details.
 """Unit tests for `iris_grib.grib_save_rules.identification`."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 import gribapi
-import mock
 
 import iris
 import iris.tests.stock as stock

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_1.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_1.py
@@ -8,16 +8,14 @@ Unit tests for :func:`iris_grib._save_rules.product_definition_template_1`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock
@@ -57,7 +55,7 @@ class TestRealizationIdentifier(tests.IrisGribTest):
         cube.add_aux_coord(coord, 0)
 
         msg = "'realization' coordinate with one point is required"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             product_definition_template_1(cube, mock.sentinel.grib)
 
 

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_10.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_10.py
@@ -8,16 +8,14 @@ Unit tests for :func:`iris_grib._save_rules.product_definition_template_10`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import DimCoord
 import iris.tests.stock as stock
@@ -55,7 +53,7 @@ class TestPercentileValueIdentifier(tests.IrisGribTest):
         cube.add_aux_coord(percentile_coord, 0)
         err_msg = "A cube 'percentile_over_time' coordinate with one point "\
                   "is required"
-        with self.assertRaisesRegexp(ValueError, err_msg):
+        with self.assertRaisesRegex(ValueError, err_msg):
             product_definition_template_10(cube, mock.sentinel.grib)
 
 

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_11.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_11.py
@@ -8,16 +8,14 @@ Unit tests for :func:`iris_grib._save_rules.product_definition_template_11`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_15.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_15.py
@@ -8,16 +8,14 @@ Unit tests for :func:`iris_grib._save_rules.product_definition_template_15`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_40.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_40.py
@@ -8,16 +8,14 @@ Unit tests for :func:`iris_grib._save_rules.product_definition_template_40`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import DimCoord
 import iris.tests.stock as stock

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_8.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_8.py
@@ -8,16 +8,14 @@ Unit tests for :func:`iris_grib._save_rules.product_definition_template_8`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock

--- a/iris_grib/tests/unit/save_rules/test_reference_time.py
+++ b/iris_grib/tests/unit/save_rules/test_reference_time.py
@@ -5,15 +5,13 @@
 # licensing details.
 """Unit tests for `iris_grib.grib_save_rules.reference_time`."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 import gribapi
-import mock
 
 from iris_grib import load_cubes
 from iris_grib._save_rules import reference_time

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -8,9 +8,6 @@ Unit tests for :func:`iris_grib._save_rules.set_fixed_surfaces`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests

--- a/iris_grib/tests/unit/save_rules/test_set_time_increment.py
+++ b/iris_grib/tests/unit/save_rules/test_set_time_increment.py
@@ -8,15 +8,13 @@ Unit tests for :func:`iris_grib._save_rules.set_time_increment`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 import gribapi
-import mock
 
 from iris.coords import CellMethod
 

--- a/iris_grib/tests/unit/save_rules/test_set_time_range.py
+++ b/iris_grib/tests/unit/save_rules/test_set_time_range.py
@@ -8,19 +8,15 @@ Unit tests for :func:`iris_grib._save_rules.set_time_range`
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
 import warnings
 
 from cf_units import Unit
 import gribapi
-import mock
 
 from iris.coords import DimCoord
 
@@ -34,21 +30,21 @@ class Test(tests.IrisGribTest):
                                          calendar='standard'))
 
     def test_no_bounds(self):
-        with self.assertRaisesRegexp(ValueError, 'Expected time coordinate '
-                                     'with two bounds, got 0 bounds'):
+        with self.assertRaisesRegex(ValueError, 'Expected time coordinate '
+                                    'with two bounds, got 0 bounds'):
             set_time_range(self.coord, mock.sentinel.grib)
 
     def test_three_bounds(self):
         self.coord.bounds = [0, 1, 2]
-        with self.assertRaisesRegexp(ValueError, 'Expected time coordinate '
-                                     'with two bounds, got 3 bounds'):
+        with self.assertRaisesRegex(ValueError, 'Expected time coordinate '
+                                    'with two bounds, got 3 bounds'):
             set_time_range(self.coord, mock.sentinel.grib)
 
     def test_non_scalar(self):
         coord = DimCoord([0, 1], 'time', bounds=[[0, 1], [1, 2]],
                          units=Unit('hours since epoch', calendar='standard'))
-        with self.assertRaisesRegexp(ValueError, 'Expected length one time '
-                                     'coordinate, got 2 points'):
+        with self.assertRaisesRegex(ValueError, 'Expected length one time '
+                                    'coordinate, got 2 points'):
             set_time_range(coord, mock.sentinel.grib)
 
     @mock.patch.object(gribapi, 'grib_set')
@@ -86,7 +82,7 @@ class Test(tests.IrisGribTest):
         self.assertEqual(len(warn), 1)
         msg = 'Truncating floating point lengthOfTimeRange 10\.8?9+ ' \
               'to integer value 10'
-        six.assertRegex(self, str(warn[0].message), msg)
+        self.assertRegex(str(warn[0].message), msg)
         mock_set_long.assert_any_call(mock.sentinel.grib,
                                       'indicatorOfUnitForTimeRange', 1)
         mock_set_long.assert_any_call(mock.sentinel.grib,

--- a/iris_grib/tests/unit/test_GribWrapper.py
+++ b/iris_grib/tests/unit/test_GribWrapper.py
@@ -8,15 +8,12 @@ Unit tests for the `iris_grib.GribWrapper` class.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
-import mock
 import numpy as np
+from unittest import mock
 
 from iris._lazy_data import as_concrete_data, is_lazy_data
 from iris.exceptions import TranslationError
@@ -68,7 +65,7 @@ class Test_edition(tests.IrisGribTest):
 
         emsg = "GRIB edition 2 is not supported by 'GribWrapper'"
         with mock.patch('gribapi.grib_get_long', func):
-            with self.assertRaisesRegexp(TranslationError, emsg):
+            with self.assertRaisesRegex(TranslationError, emsg):
                 GribWrapper(None)
 
     def test_edition_1(self):

--- a/iris_grib/tests/unit/test__load_generate.py
+++ b/iris_grib/tests/unit/test__load_generate.py
@@ -5,12 +5,9 @@
 # licensing details.
 """Unit tests for the `iris_grib._load_generate` function."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 import iris
 from iris.exceptions import TranslationError
@@ -61,7 +58,7 @@ class Test(tests.IrisGribTest):
         mfunc = 'iris_grib.GribMessage.messages_from_filename'
         emsg = 'GRIB edition 0 is not supported'
         with mock.patch(mfunc, return_value=[message]):
-            with self.assertRaisesRegexp(TranslationError, emsg):
+            with self.assertRaisesRegex(TranslationError, emsg):
                 next(_load_generate(self.fname))
 
 

--- a/iris_grib/tests/unit/test_load_cubes.py
+++ b/iris_grib/tests/unit/test_load_cubes.py
@@ -5,12 +5,9 @@
 # licensing details.
 """Unit tests for the `iris_grib.load_cubes` function."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 import iris
 from iris.fileformats.rules import Loader

--- a/iris_grib/tests/unit/test_save_grib2.py
+++ b/iris_grib/tests/unit/test_save_grib2.py
@@ -5,15 +5,11 @@
 # licensing details.
 """Unit tests for the `iris_grib.save_grib2` function."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
-import mock
+from unittest import mock
 
 import iris_grib
 

--- a/iris_grib/tests/unit/test_save_messages.py
+++ b/iris_grib/tests/unit/test_save_messages.py
@@ -5,17 +5,13 @@
 # licensing details.
 """Unit tests for the `iris_grib.save_messages` function."""
 
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-import six
-
 # Import iris_grib.tests first so that some things can be initialised before
 # importing anything else.
 import iris_grib.tests as tests
 
 import gribapi
-import mock
 import numpy as np
+from unittest import mock
 
 import iris_grib
 
@@ -26,12 +22,8 @@ class TestSaveMessages(tests.IrisGribTest):
         self.grib_message = gribapi.grib_new_from_samples("GRIB2")
 
     def test_save(self):
-        if six.PY3:
-            open_func = 'builtins.open'
-        else:
-            open_func = '__builtin__.open'
         m = mock.mock_open()
-        with mock.patch(open_func, m, create=True):
+        with mock.patch('builtins.open', m, create=True):
             # sending a MagicMock object to gribapi raises an AssertionError
             # as the gribapi code does a type check
             # this is deemed acceptable within the scope of this unit test
@@ -40,12 +32,8 @@ class TestSaveMessages(tests.IrisGribTest):
         self.assertTrue(mock.call('foo.grib2', 'wb') in m.mock_calls)
 
     def test_save_append(self):
-        if six.PY3:
-            open_func = 'builtins.open'
-        else:
-            open_func = '__builtin__.open'
         m = mock.mock_open()
-        with mock.patch(open_func, m, create=True):
+        with mock.patch('builtins.open', m, create=True):
             # sending a MagicMock object to gribapi raises an AssertionError
             # as the gribapi code does a type check
             # this is deemed acceptable within the scope of this unit test

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 import os
 import os.path


### PR DESCRIPTION
This removes (hopefully) all Python 2 support from iris_grib.

I have checked for :
* six
* `__future__`
* class <name_of_class>(object):
* super arguments
* mock rather than unittest.mock
* `assertRaisesRegexp` > `assertRaisesRegex`

Note ! I have not touched [_grib_cf_map.py](https://github.com/SciTools/iris-grib/blob/master/iris_grib/_grib_cf_map.py) as that file is auto-generated and so should not be manually modified