### PR TITLE
Add release notes for 0.14.1 release (GH-162)

### DIFF
--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -22,7 +22,7 @@ Features
 Bug Fixes
 ^^^^^^^^^
 
-* Add fixes to get iris-grib working with the Python 3 compatible release of
+* Added fixes to get iris-grib working with the Python 3 compatible release of
   eccodes. This included workarounds such that lists that are returned by
   eccodes are converted to NumPy arrays as expected.
 
@@ -101,4 +101,3 @@ What's new in iris-grib v0.9
 :Date: 25 Jul 2016
 
 Stable release of iris-grib to support iris v1.10
-

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -16,6 +16,16 @@ Features
   area at a horizontal level or in a horizontal layer at a point in time
   (product definition template 15 in code table 4.0)
 
+:Release: 0.14.1
+:Date: 12 Jun 2019
+
+Bug Fixes
+^^^^^^^^^
+
+* Add fixes to get iris-grib working with the Python 3 compatible release of
+  eccodes. This included workarounds such that lists that are returned by
+  eccodes are converted to NumPy arrays as expected.
+
 
 What's new in iris-grib v0.13
 -----------------------------


### PR DESCRIPTION
Much to my surprise, it turns out we have release notes in iris-grib docs! 

This updates the docs to include notes about the 0.14.1 release, which I missed when I did that release)

I've made this change to the v0.14.x branch in case we do another 0.14 release, but once it is in, we can merge it into master.

Note the build of the docs is broken for some reason ? (I've capture it here #163 )