### PR TITLE
Add release notes for 0.15 release

### DIFF
--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -1,6 +1,42 @@
 Release Notes
 =============
 
+
+What's new in iris-grib v0.15
+-----------------------------
+
+:Release: 0.15.0
+:Date: 4 Dec 2019
+
+Features
+^^^^^^^^
+
+* Updated translations between GRIB parameter code and CF standard_name or
+  long_name
+
+* Added support for loading GRIB messages with no fixed surface set in the
+  product definition section
+
+* Added support for loading GRIB messages where i or j increment are not set
+
+* Added support for saving cubes that have a "depth" coordinate
+
+* Cubes loaded from GRIB files now contain a new GRIB_PARAM attribute, the
+  value of which is an instance of
+  iris_grib.grib_phenom_translation.GRIBCode and represents the parameter code
+  
+Bug Fixes
+^^^^^^^^^
+
+* Reverted a bug that was fixed in v0.13 related to loading hybrid pressure 
+  levels. It was agreed that the initial behaviour was correct 
+
+Dependencies
+^^^^^^^^^^^^
+
+* Python 2 is no longer supported
+
+
 What's new in iris-grib v0.14
 -----------------------------
 

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -6,13 +6,17 @@ What's new in iris-grib v0.15
 -----------------------------
 
 :Release: 0.15.0
-:Date: 4 Dec 2019
+:Date: 5 Dec 2019
 
 Features
 ^^^^^^^^
 
 * Updated translations between GRIB parameter code and CF standard_name or
-  long_name
+  long_name :
+      * additional WAFC codes, both to and from CF
+      * 'mass_fraction_of_cloud_liquid_water_in_air' and 'mass_fraction_of_cloud_ice_in_air', both to and from CF
+      * 'surface_downwelling_longwave_flux_in_air', now translates to GRIBcode(2, 0, 5, 3)  (but not the reverse).
+      * for full details, see : https://github.com/Scitools/iris-grib/compare/c4243ae..5c314e3#diff-cf46b46880cae59e82a91c7ab6bb81ba
 
 * Added support for loading GRIB messages with no fixed surface set in the
   product definition section
@@ -23,7 +27,9 @@ Features
 
 * Cubes loaded from GRIB files now contain a new GRIB_PARAM attribute, the
   value of which is an instance of
-  iris_grib.grib_phenom_translation.GRIBCode and represents the parameter code
+  iris_grib.grib_phenom_translation.GRIBCode and represents the parameter code.
+  When saving, if a cube has a GRIBCode attribute, this determines the parameter code
+  in the created message(s): This will _override_ any translation from the CF names.
   
 Bug Fixes
 ^^^^^^^^^
@@ -127,4 +133,3 @@ What's new in iris-grib v0.9
 :Date: 25 Jul 2016
 
 Stable release of iris-grib to support iris v1.10
-

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -1,7 +1,6 @@
 Release Notes
 =============
 
-
 What's new in iris-grib v0.15
 -----------------------------
 
@@ -133,3 +132,4 @@ What's new in iris-grib v0.9
 :Date: 25 Jul 2016
 
 Stable release of iris-grib to support iris v1.10
+


### PR DESCRIPTION
I wrote up a summary of what changed in the 0.15 release.

The question is, does this go in before or after we cut the 0.15 release?