### PR TITLE
Bump version to 0.16.0dev0 (master branch)

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -32,7 +32,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.15.0'
+__version__ = '0.16.0dev0'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']


### PR DESCRIPTION
Note that this is pointing at the master branch

I'm assuming we are not ready for a major release yet (i.e. no iris-grib v1) so the next release will be iris-grib 0.16