### PR TITLE
Latest Iris Compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 channels:
     - conda-forge
 dependencies:
-    - iris=2.*
+    - iris>=2
     - python-eccodes>=0.9.1,<2

--- a/environment.yml
+++ b/environment.yml
@@ -3,3 +3,4 @@ channels:
 dependencies:
     - iris>=2
     - python-eccodes>=0.9.1,<2
+    - pep8

--- a/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
+++ b/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
@@ -14,7 +14,7 @@ hybrid pressure cubes.
 import iris_grib.tests as tests
 
 from iris import load_cube, load_cubes, save
-from iris.experimental.equalise_cubes import equalise_attributes
+from iris.util import equalise_attributes
 
 
 class TestHybridHeightRoundTrip(tests.IrisGribTest):

--- a/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
+++ b/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
@@ -118,13 +118,13 @@ class Test_GribLevels(tests.IrisTest):
 
         ml_ref = iris.coords.CoordDefn('model_level_number', None, None,
                                        cf_units.Unit('1'),
-                                       {'positive': 'up'}, None)
+                                       {'positive': 'up'}, None, False)
         lp_ref = iris.coords.CoordDefn(None, 'level_pressure', None,
                                        cf_units.Unit('Pa'),
-                                       {}, None)
+                                       {}, None, False)
         s_ref = iris.coords.CoordDefn(None, 'sigma', None,
                                       cf_units.Unit('1'),
-                                      {}, None)
+                                      {}, None, False)
 
         aux_coord_defns = [coord._as_defn() for coord, dim in results[8]]
         self.assertIn(ml_ref, aux_coord_defns)


### PR DESCRIPTION
This PR makes some minor changes that allow the latest Iris-GRIB to be installed alongside the latest Iris, including ensuring that the Iris-GRIB tests can run.

_Note that Iris-GRIB includes a pep8 test, but pep8 is not included in [environment.yml](https://github.com/SciTools/iris-grib/blob/master/environment.yml) since it is not a core requirement. In the past, pep8 would be included with a full Iris install, but that is no longer the case since Iris was switched to black syntax, so running the tests from the command line may error on the pep8 test depending on the user's install. pep8 is however installed during the Travis tests._