### PR TITLE
Get iris-grib tests passing with the latest version of eccodes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,5 +2,5 @@ channels:
     - conda-forge
 dependencies:
     - iris>=2
-    - python-eccodes>=0.9.1,<2
+    - python-eccodes
     - pep8

--- a/iris_grib/tests/unit/test_save_messages.py
+++ b/iris_grib/tests/unit/test_save_messages.py
@@ -10,7 +10,6 @@
 import iris_grib.tests as tests
 
 import gribapi
-import numpy as np
 from unittest import mock
 
 import iris_grib
@@ -24,22 +23,14 @@ class TestSaveMessages(tests.IrisGribTest):
     def test_save(self):
         m = mock.mock_open()
         with mock.patch('builtins.open', m, create=True):
-            # sending a MagicMock object to gribapi raises an AssertionError
-            # as the gribapi code does a type check
-            # this is deemed acceptable within the scope of this unit test
-            with self.assertRaises((AssertionError, TypeError)):
-                iris_grib.save_messages([self.grib_message], 'foo.grib2')
+            iris_grib.save_messages([self.grib_message], 'foo.grib2')
         self.assertTrue(mock.call('foo.grib2', 'wb') in m.mock_calls)
 
     def test_save_append(self):
         m = mock.mock_open()
         with mock.patch('builtins.open', m, create=True):
-            # sending a MagicMock object to gribapi raises an AssertionError
-            # as the gribapi code does a type check
-            # this is deemed acceptable within the scope of this unit test
-            with self.assertRaises((AssertionError, TypeError)):
-                iris_grib.save_messages([self.grib_message], 'foo.grib2',
-                                        append=True)
+            iris_grib.save_messages([self.grib_message], 'foo.grib2',
+                                    append=True)
         self.assertTrue(mock.call('foo.grib2', 'ab') in m.mock_calls)
 
 


### PR DESCRIPTION
Previously a couple tests were failing with eccodes> 2.14 as eccodes was no longer raising an error when you give it a mock object.  This fixes those tests.

The environment currently resolves with eccodes 2.16