### PR TITLE
Fix dask2 proxies 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 channels:
     - conda-forge
 dependencies:
-    - iris>=2
+    - iris>=2.4
     - python-eccodes>=0.9.1,<2
     - pep8

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -20,79 +20,13 @@ import gribapi
 import numpy as np
 import numpy.ma as ma
 
+# NOTE: careful here, to avoid circular imports (as iris imports grib)
 import iris
 from iris._lazy_data import as_lazy_data
 import iris.coord_systems as coord_systems
 from iris.exceptions import TranslationError, NotYetImplementedError
+from iris.util import _array_slice_ifempty
 
-try:
-    from iris.util import _array_slice_ifempty
-except ImportError:
-    # A temporary cut-and-paste hack, until this is in an Iris release ...
-    # see : https://github.com/SciTools/iris/pull/3659
-    def _array_slice_ifempty(keys, shape, dtype):
-        """
-        Detect cases where an array slice will contain no data, as it contains
-        a zero-length dimension, and produce an equivalent result for those
-        cases.
-
-        The function indicates 'empty' slicing cases, by returning an array
-        equal to the slice result in those cases.
-
-        Args:
-
-        * keys (indexing key, or tuple of keys):
-            The argument from an array __getitem__ call.
-            Only tuples of integers and slices are supported, in particular no
-            newaxis, ellipsis or array keys.
-            These are the types of array access usage we expect from Dask.
-        * shape (tuple of int):
-            The shape of the array being indexed.
-        * dtype (numpy.dtype):
-            The dtype of the array being indexed.
-
-        Returns:
-            result (np.ndarray or None):
-                If 'keys' contains a slice(0, 0), this is an ndarray of the
-                correct resulting shape and provided dtype.
-                Otherwise it is None.
-
-        .. note::
-
-            This is used to prevent DataProxy arraylike objects from fetching
-            their file data when wrapped as Dask arrays.
-            This is because, for Dask >= 2.0, the "dask.array.from_array" call
-            performs a fetch like [0:0, 0:0, ...], to snapshot array metadata.
-            This function enables us to avoid triggering a file data fetch in
-            those cases :  This is consistent because the result will not
-            contain any actual data content.
-
-        """
-        # Convert single key into a 1-tuple, so we always have a tuple of keys.
-        if isinstance(keys, tuple):
-            keys_tuple = keys
-        else:
-            keys_tuple = (keys,)
-
-        if any(key == slice(0, 0) for key in keys_tuple):
-            # An 'empty' slice is present :  Return a 'fake' array instead.
-            target_shape = list(shape)
-            for i_dim, key in enumerate(keys_tuple):
-                if key == slice(0, 0):
-                    # Reduce dims with empty slicing to length 0.
-                    target_shape[i_dim] = 0
-            # Create a prototype result : no memory usage, as some dims are 0.
-            result = np.zeros(target_shape, dtype=dtype)
-            # Index with original keys to produce the desired result shape.
-            # Note : also ok in 0-length dims, as the slice is always '0:0'.
-            result = result[keys]
-        else:
-            result = None
-
-        return result
-
-
-# NOTE: careful here, to avoid circular imports (as iris imports grib)
 from . import grib_phenom_translation as gptx
 from . import _save_rules
 from ._load_convert import convert as load_convert

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -92,7 +92,6 @@ except ImportError:
         return result
 
 
-
 # NOTE: careful here, to avoid circular imports (as iris imports grib)
 from . import grib_phenom_translation as gptx
 from . import _save_rules

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 import re
 
 import gribapi
-from iris_grib import _fake_empty_getitem as fake_empty_getitem
+from iris_grib import _array_slice_ifempty
 import numpy as np
 import numpy.ma as ma
 
@@ -232,7 +232,7 @@ class _DataProxy:
 
         # Avoid fetching file data just to return an 'empty' result.
         # Needed because of how dask.array.from_array behaves since Dask v2.0.
-        result = fake_empty_getitem(keys=keys, shape=self.shape, self.dtype)
+        result = _array_slice_ifempty(keys, self.shape, self.dtype)
         if result is None:
             message = self.recreate_raw()
             sections = message.sections

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -12,6 +12,7 @@ from collections import namedtuple
 import re
 
 import gribapi
+from iris_grib import _fake_empty_getitem as fake_empty_getitem
 import numpy as np
 import numpy.ma as ma
 
@@ -228,29 +229,35 @@ class _DataProxy:
     def __getitem__(self, keys):
         # NB. Currently assumes that the validity of this interpretation
         # is checked before this proxy is created.
-        message = self.recreate_raw()
-        sections = message.sections
-        bitmap_section = sections[6]
-        bitmap = self._bitmap(bitmap_section)
-        data = sections[7]['codedValues']
 
-        if bitmap is not None:
-            # Note that bitmap and data are both 1D arrays at this point.
-            if np.count_nonzero(bitmap) == data.shape[0]:
-                # Only the non-masked values are included in codedValues.
-                _data = np.empty(shape=bitmap.shape)
-                _data[bitmap.astype(bool)] = data
-                # `ma.masked_array` masks where input = 1, the opposite of
-                # the behaviour specified by the GRIB spec.
-                data = ma.masked_array(_data, mask=np.logical_not(bitmap),
-                                       fill_value=np.nan)
-            else:
-                msg = 'Shapes of data and bitmap do not match.'
-                raise TranslationError(msg)
+        # Avoid fetching file data just to return an 'empty' result.
+        # Needed because of how dask.array.from_array behaves since Dask v2.0.
+        result = fake_empty_getitem(keys=keys, shape=self.shape, self.dtype)
+        if result is None:
+            message = self.recreate_raw()
+            sections = message.sections
+            bitmap_section = sections[6]
+            bitmap = self._bitmap(bitmap_section)
+            data = sections[7]['codedValues']
 
-        data = data.reshape(self.shape)
+            if bitmap is not None:
+                # Note that bitmap and data are both 1D arrays at this point.
+                if np.count_nonzero(bitmap) == data.shape[0]:
+                    # Only the non-masked values are included in codedValues.
+                    _data = np.empty(shape=bitmap.shape)
+                    _data[bitmap.astype(bool)] = data
+                    # `ma.masked_array` masks where input = 1, the opposite of
+                    # the behaviour specified by the GRIB spec.
+                    data = ma.masked_array(_data, mask=np.logical_not(bitmap),
+                                           fill_value=np.nan)
+                else:
+                    msg = 'Shapes of data and bitmap do not match.'
+                    raise TranslationError(msg)
 
-        return data.__getitem__(keys)
+            data = data.reshape(self.shape)
+            result = data.__getitem__(keys)
+
+        return result
 
     def __repr__(self):
         msg = '<{self.__class__.__name__} shape={self.shape} ' \

--- a/iris_grib/tests/unit/message/test__DataProxy.py
+++ b/iris_grib/tests/unit/message/test__DataProxy.py
@@ -44,7 +44,7 @@ class Test__bitmap(tests.IrisGribTest):
 
 
 class Test_emptyfetch(tests.IrisGribTest):
-    # See : 
+    # See :
     #   iris.tests.unit.fileformats.pp.test_PPDataProxy.Test__getitem__slicing
     # In this case, test *only* the no-data-read effect, not the method which
     # is part of Iris.

--- a/iris_grib/tests/unit/message/test__DataProxy.py
+++ b/iris_grib/tests/unit/message/test__DataProxy.py
@@ -12,6 +12,8 @@ Unit tests for the `iris.message._DataProxy` class.
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 import numpy as np
 from numpy.random import randint
 
@@ -39,6 +41,32 @@ class Test__bitmap(tests.IrisGribTest):
         data_proxy = _DataProxy(0, 0, 0)
         with self.assertRaisesRegex(TranslationError, 'unsupported bitmap'):
             data_proxy._bitmap(section_6)
+
+
+class Test_emptyfetch(tests.IrisGribTest):
+    # See : 
+    #   iris.tests.unit.fileformats.pp.test_PPDataProxy.Test__getitem__slicing
+    # In this case, test *only* the no-data-read effect, not the method which
+    # is part of Iris.
+    def test_empty_slice(self):
+        # Check behaviour of the getitem call with an 'empty' slicing.
+        # This is necessary because, since Dask 2.0, the "from_array" function
+        # takes a zero-length slice of its array argument, to capture array
+        # metadata, and in those cases we want to avoid file access.
+        test_dtype = np.dtype(np.float32)
+        mock_datafetch = mock.MagicMock()
+        proxy = _DataProxy(shape=(3, 4),
+                           dtype=np.dtype(np.float32),
+                           recreate_raw=mock_datafetch)
+
+        # Test the special no-data indexing operation.
+        result = proxy[0:0, 0:0]
+
+        # Check the behaviour and results were as expected.
+        self.assertEqual(mock_datafetch.call_count, 0)
+        self.assertIsInstance(result, np.ndarray)
+        self.assertEqual(result.dtype, test_dtype)
+        self.assertEqual(result.shape, (0, 0))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup_args = dict(
     # NOTE: The Python 3 bindings to eccodes (eccodes-python) is available on
     # PyPI, but the user is required to install eccodes itself manually. See 
     # ECMWF ecCodes installation documentation for more information.
-    install_requires=['scitools-iris>=2.0.*'] + ['eccodes-python'],
+    install_requires=['scitools-iris>=2.4.*'] + ['eccodes-python'],
     test_suite = 'iris_grib.tests',
 )
 


### PR DESCRIPTION
Change that parallels https://github.com/SciTools/iris/pull/3659

**NOTE:** 
This contains a [temporary copy](https://github.com/SciTools/iris-grib/blob/fbe926137dafea6eac4db908d7f1c18f56f35002/iris_grib/__init__.py#L33) of the [key Iris routine](https://github.com/SciTools/iris/blob/9b8f9cbf943b2c659dcae2765e1cab089cabc645/lib/iris/util.py#L918) that enables this fix.
This can be removed when Iris 2.4 is out.
Not clear if we should merge this as-is, or wait for that ?

