### PR TITLE
Pin eccodes to avoid bad version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,5 +2,5 @@ channels:
     - conda-forge
 dependencies:
     - iris>=2
-    - python-eccodes
+    - python-eccodes>=0.9.1,<2
     - pep8

--- a/iris_grib/tests/unit/test_save_messages.py
+++ b/iris_grib/tests/unit/test_save_messages.py
@@ -23,14 +23,22 @@ class TestSaveMessages(tests.IrisGribTest):
     def test_save(self):
         m = mock.mock_open()
         with mock.patch('builtins.open', m, create=True):
-            iris_grib.save_messages([self.grib_message], 'foo.grib2')
+            # sending a MagicMock object to gribapi raises an AssertionError
+            # as the gribapi code does a type check
+            # this is deemed acceptable within the scope of this unit test
+            with self.assertRaises((AssertionError, TypeError)):
+                iris_grib.save_messages([self.grib_message], 'foo.grib2')
         self.assertTrue(mock.call('foo.grib2', 'wb') in m.mock_calls)
 
     def test_save_append(self):
         m = mock.mock_open()
         with mock.patch('builtins.open', m, create=True):
-            iris_grib.save_messages([self.grib_message], 'foo.grib2',
-                                    append=True)
+            # sending a MagicMock object to gribapi raises an AssertionError
+            # as the gribapi code does a type check
+            # this is deemed acceptable within the scope of this unit test
+            with self.assertRaises((AssertionError, TypeError)):
+                iris_grib.save_messages([self.grib_message], 'foo.grib2',
+                                        append=True)
         self.assertTrue(mock.call('foo.grib2', 'ab') in m.mock_calls)
 
 


### PR DESCRIPTION
Unfortunately, due to problems with saving in the latest eccodes version (2.16) (as shown [in these tests](https://travis-ci.org/SciTools/iris-grib/jobs/652968694?utm_medium=notification&utm_source=github_status)), we will have to pin back to using an older version of eccodes.

This is effectively undoing the changes in #189
