### PR TITLE
Port tests from iris/tests/test_grib_save_rules.py from iris

### DIFF
--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_8.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_8.py
@@ -16,8 +16,10 @@ from unittest import mock
 
 from cf_units import Unit
 import gribapi
+import numpy as np
 
 from iris.coords import CellMethod, DimCoord
+import iris.cube
 import iris.tests.stock as stock
 
 from iris_grib._save_rules import product_definition_template_8
@@ -41,6 +43,34 @@ class TestProductDefinitionIdentifier(tests.IrisGribTest):
         product_definition_template_8(cube, mock.sentinel.grib)
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "productDefinitionTemplateNumber", 8)
+
+
+class Test_type_of_statistical_processing(tests.IrisTest):
+    @mock.patch.object(gribapi, "grib_set")
+    def test_stats_type_min(self, mock_set):
+        grib = None
+        cube = iris.cube.Cube(np.array([1.0]))
+        time_unit = Unit("hours since 1970-01-01 00:00:00")
+        time_coord = iris.coords.DimCoord(
+            [0.0], bounds=[0.0, 1], standard_name="time", units=time_unit
+        )
+        cube.add_aux_coord(time_coord, ())
+        cube.add_cell_method(iris.coords.CellMethod("maximum", time_coord))
+        product_definition_template_8(cube, grib)
+        mock_set.assert_any_call(grib, "typeOfStatisticalProcessing", 2)
+
+    @mock.patch.object(gribapi, "grib_set")
+    def test_stats_type_max(self, mock_set):
+        grib = None
+        cube = iris.cube.Cube(np.array([1.0]))
+        time_unit = Unit("hours since 1970-01-01 00:00:00")
+        time_coord = iris.coords.DimCoord(
+            [0.0], bounds=[0.0, 1], standard_name="time", units=time_unit
+        )
+        cube.add_aux_coord(time_coord, ())
+        cube.add_cell_method(iris.coords.CellMethod("minimum", time_coord))
+        product_definition_template_8(cube, grib)
+        mock_set.assert_any_call(grib, "typeOfStatisticalProcessing", 3)
 
 
 if __name__ == "__main__":

--- a/iris_grib/tests/unit/save_rules/test_set_discipline_and_parameter.py
+++ b/iris_grib/tests/unit/save_rules/test_set_discipline_and_parameter.py
@@ -49,6 +49,11 @@ class TestPhenomenonCoding(tests.IrisGribTest):
         cube.standard_name = 'sea_water_y_velocity'
         self._check_coding(cube, 10, 1, 3)  # as seen in _grib_cf_map.py
 
+    def test_known_long_name(self):
+        cube = self.mock_cube
+        cube.long_name = 'cloud_mixing_ratio'
+        self._check_coding(cube, 0, 1, 22)
+
     def test_gribcode_attribute_object(self):
         cube = self.mock_cube
         cube.attributes = {'GRIB_PARAM': GRIBCode(2, 7, 12, 99)}

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -12,6 +12,8 @@ Unit tests for :func:`iris_grib._save_rules.set_fixed_surfaces`.
 # importing anything else.
 import iris_grib.tests as tests
 
+from unittest import mock
+
 import gribapi
 import numpy as np
 
@@ -82,6 +84,54 @@ class Test(tests.IrisGribTest):
         self.assertEqual(
             gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
             106)
+
+    @mock.patch.object(gribapi, "grib_set")
+    def test_altitude_point(self, mock_set):
+        grib = None
+        cube = iris.cube.Cube([1, 2, 3, 4, 5])
+        cube.add_aux_coord(
+            iris.coords.AuxCoord([12345], "altitude", units="m")
+        )
+
+        set_fixed_surfaces(cube, grib)
+
+        mock_set.assert_any_call(grib, "typeOfFirstFixedSurface", 102)
+        mock_set.assert_any_call(grib, "scaleFactorOfFirstFixedSurface", 0)
+        mock_set.assert_any_call(grib, "scaledValueOfFirstFixedSurface",
+                                 12345)
+        mock_set.assert_any_call(grib, "typeOfSecondFixedSurface", -1)
+        mock_set.assert_any_call(grib, "scaleFactorOfSecondFixedSurface",
+                                 255)
+        mock_set.assert_any_call(grib, "scaledValueOfSecondFixedSurface",
+                                 -1)
+
+    @mock.patch.object(gribapi, "grib_set")
+    def test_height_point(self, mock_set):
+        grib = None
+        cube = iris.cube.Cube([1, 2, 3, 4, 5])
+        cube.add_aux_coord(iris.coords.AuxCoord([12345], "height", units="m"))
+
+        set_fixed_surfaces(cube, grib)
+
+        mock_set.assert_any_call(grib, "typeOfFirstFixedSurface", 103)
+        mock_set.assert_any_call(grib, "scaleFactorOfFirstFixedSurface", 0)
+        mock_set.assert_any_call(grib, "scaledValueOfFirstFixedSurface", 12345)
+        mock_set.assert_any_call(grib, "typeOfSecondFixedSurface", -1)
+        mock_set.assert_any_call(grib, "scaleFactorOfSecondFixedSurface", 255)
+        mock_set.assert_any_call(grib, "scaledValueOfSecondFixedSurface", -1)
+
+
+    @mock.patch.object(gribapi, "grib_set")
+    def test_no_vertical(self, mock_set):
+        grib = None
+        cube = iris.cube.Cube([1, 2, 3, 4, 5])
+        set_fixed_surfaces(cube, grib)
+        mock_set.assert_any_call(grib, "typeOfFirstFixedSurface", 1)
+        mock_set.assert_any_call(grib, "scaleFactorOfFirstFixedSurface", 0)
+        mock_set.assert_any_call(grib, "scaledValueOfFirstFixedSurface", 0)
+        mock_set.assert_any_call(grib, "typeOfSecondFixedSurface", -1)
+        mock_set.assert_any_call(grib, "scaleFactorOfSecondFixedSurface", 255)
+        mock_set.assert_any_call(grib, "scaledValueOfSecondFixedSurface", -1)
 
 
 if __name__ == "__main__":

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -120,7 +120,6 @@ class Test(tests.IrisGribTest):
         mock_set.assert_any_call(grib, "scaleFactorOfSecondFixedSurface", 255)
         mock_set.assert_any_call(grib, "scaledValueOfSecondFixedSurface", -1)
 
-
     @mock.patch.object(gribapi, "grib_set")
     def test_no_vertical(self, mock_set):
         grib = None


### PR DESCRIPTION
Companion PR: https://github.com/SciTools/iris/pull/3666

The tests contained various unit tests so I split them up and put them in the correct places.

Note this doesn't include ALL the tests from iris/tests/test_grib_save_rules.py as there were some duplications. Check the iris PR for more information