### PR TITLE
Port pickling test from Iris.

### DIFF
--- a/iris_grib/tests/integration/iris_integration/test_pickle_message.py
+++ b/iris_grib/tests/integration/iris_integration/test_pickle_message.py
@@ -1,0 +1,69 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Check that a GribMessage can be pickled."""
+
+# Import iris_grib.tests first so that some things can be initialised before
+# importing anything else.
+import iris_grib.tests as tests
+
+import pickle
+import unittest
+
+from iris.tests.integration.test_pickle import Common as PickleCommon
+
+from iris_grib.message import GribMessage
+
+
+@tests.skip_data
+class TestPickleGribMessage(PickleCommon, tests.IrisGribTest):
+    # NOTE: based on 'Common' from iris.tests.integration.test_pickle.
+    def setUp(self):
+        self.path = tests.get_data_path(("GRIB", "fp_units", "hours.grib2"))
+
+    # NOTE: this looks like it is overriding the parent "pickle_cube", but this
+    # function is *not* the same thing.
+    # (a) the tests which use pickle_cube are "test_protocol_XXX", and none
+    #     of those currently work (see overrides below).
+    # (b) the tests which use *this* function are the extra ones below.
+    #     These check only that a GribMessage, and its lazy ".data" can be
+    #     pickled.  However, still, neither reads back successfully.
+    # TODO: resolve this or remove the test.
+    def pickle_obj(self, obj):
+        with self.temp_filename(".pkl") as filename:
+            with open(filename, "wb") as f:
+                pickle.dump(obj, f)
+            # NOTE: *ought* to read back + check equal, but it does not work.
+            # TODO: fix
+
+    # These probably "ought" to work, but currently fail.
+    # see https://github.com/SciTools/iris/pull/2608
+    @unittest.expectedFailure
+    def test_protocol_0(self):
+        super().test_protocol_0()
+
+    @unittest.expectedFailure
+    def test_protocol_1(self):
+        super().test_protocol_1()
+
+    @unittest.expectedFailure
+    def test_protocol_2(self):
+        super().test_protocol_2()
+
+    def test(self):
+        # Check that a GribMessage pickles without errors.
+        messages = GribMessage.messages_from_filename(self.path)
+        obj = next(messages)
+        self.pickle_obj(obj)
+
+    def test_data(self):
+        # Check that GribMessage.data pickles without errors.
+        messages = GribMessage.messages_from_filename(self.path)
+        obj = next(messages).data
+        self.pickle_obj(obj)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/iris_grib/tests/integration/iris_integration/test_pickle_message.py
+++ b/iris_grib/tests/integration/iris_integration/test_pickle_message.py
@@ -28,7 +28,7 @@ class TestPickleGribMessage(PickleCommon, tests.IrisGribTest):
     # (a) the tests which use pickle_cube are "test_protocol_XXX", and none
     #     of those currently work (see overrides below).
     # (b) the tests which use *this* function are the extra ones below.
-    #     These check only that a GribMessage, and its lazy ".data" can be
+    #     These check only that a GribMessage, and its lazy ".data", can be
     #     pickled.  However, still, neither reads back successfully.
     # TODO: resolve this or remove the test.
     def pickle_obj(self, obj):
@@ -39,7 +39,7 @@ class TestPickleGribMessage(PickleCommon, tests.IrisGribTest):
             # TODO: fix
 
     # These probably "ought" to work, but currently fail.
-    # see https://github.com/SciTools/iris/pull/2608
+    # see https://github.com/SciTools/iris-grib/issues/202
     @unittest.expectedFailure
     def test_protocol_0(self):
         super().test_protocol_0()

--- a/iris_grib/tests/integration/iris_integration/test_pickle_message.py
+++ b/iris_grib/tests/integration/iris_integration/test_pickle_message.py
@@ -1,6 +1,6 @@
-# Copyright Iris contributors
+# Copyright iris-grib contributors
 #
-# This file is part of Iris and is released under the LGPL license.
+# This file is part of iris-grib and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 """Check that a GribMessage can be pickled."""


### PR DESCRIPTION
Depends on special functionality in `iris.tests.integration.test_pickle`, from which it imports.
Companion removing code from iris : https://github.com/SciTools/iris/pull/3671

**NOTE:** does at present not perform the desired testing, because the wanted functionality is currently broken, i.e. grib-based cubes cannot be pickled + restored.
#202 created to record this problem