### PR TITLE
Add support for missing timeIncrement in template 4.8

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -91,6 +91,8 @@ _TIME_RANGE_UNITS = {
     12: '12 hours',
     13: 'seconds'
 }
+# Regulation 92.1.4
+_TIME_RANGE_MISSING = 2 ** 32 - 1
 
 # Reference Code Table 4.5.
 _FIXED_SURFACE = {
@@ -1924,7 +1926,7 @@ def statistical_cell_method(section):
         raise TranslationError(msg)
 
     interval_number = section['timeIncrement']
-    if interval_number == 0:
+    if interval_number in (0, _TIME_RANGE_MISSING):
         intervals_string = None
     else:
         units_string = _TIME_RANGE_UNITS[

--- a/iris_grib/tests/unit/load_convert/test_statistical_cell_method.py
+++ b/iris_grib/tests/unit/load_convert/test_statistical_cell_method.py
@@ -45,6 +45,12 @@ class Test(tests.IrisGribTest):
         self.assertEqual(cell_method,
                          self.expected_cell_method(intervals=('3 hours',)))
 
+    def test_increment_missing(self):
+        self.section['timeIncrement'] = 2 ** 32 - 1
+        self.section['indicatorOfUnitForTimeIncrement'] = 255
+        cell_method = statistical_cell_method(self.section)
+        self.assertEqual(cell_method, self.expected_cell_method())
+
     def test_different_statistic(self):
         self.section['typeOfStatisticalProcessing'] = 6
         cell_method = statistical_cell_method(self.section)


### PR DESCRIPTION
Add support for loading GRIB2 files using template 4.8 in which the time increment between successive fields used in statistical processing is not defined.