### PR TITLE
Latest eccodes + workaround seg fault when saving

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,5 +2,5 @@ channels:
     - conda-forge
 dependencies:
     - iris>=2.4
-    - python-eccodes>=0.9.1,<2
+    - python-eccodes
     - pep8

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -1489,6 +1489,13 @@ def data_section(cube, grib):
         # Enable missing values in the grib message.
         gribapi.grib_set(grib, "bitmapPresent", 1)
         gribapi.grib_set_double(grib, "missingValue", fill_value)
+
+    # A segmentation fault is raised by `gribapi.grib_set_double_array` if it
+    # tries to cast large data to float64. As a temporary fix we cast the data
+    # upfront
+    # TODO: remove the `astype` command once eccodes (gribapi) has been fixed.
+    if data.dtype != np.float64:
+        data = data.astype(np.float64)
     gribapi.grib_set_double_array(grib, "values", data.flatten())
 
     # todo: check packing accuracy?

--- a/iris_grib/tests/unit/test_save_messages.py
+++ b/iris_grib/tests/unit/test_save_messages.py
@@ -23,22 +23,14 @@ class TestSaveMessages(tests.IrisGribTest):
     def test_save(self):
         m = mock.mock_open()
         with mock.patch('builtins.open', m, create=True):
-            # sending a MagicMock object to gribapi raises an AssertionError
-            # as the gribapi code does a type check
-            # this is deemed acceptable within the scope of this unit test
-            with self.assertRaises((AssertionError, TypeError)):
-                iris_grib.save_messages([self.grib_message], 'foo.grib2')
+            iris_grib.save_messages([self.grib_message], 'foo.grib2')
         self.assertTrue(mock.call('foo.grib2', 'wb') in m.mock_calls)
 
     def test_save_append(self):
         m = mock.mock_open()
         with mock.patch('builtins.open', m, create=True):
-            # sending a MagicMock object to gribapi raises an AssertionError
-            # as the gribapi code does a type check
-            # this is deemed acceptable within the scope of this unit test
-            with self.assertRaises((AssertionError, TypeError)):
-                iris_grib.save_messages([self.grib_message], 'foo.grib2',
-                                        append=True)
+            iris_grib.save_messages([self.grib_message], 'foo.grib2',
+                                    append=True)
         self.assertTrue(mock.call('foo.grib2', 'ab') in m.mock_calls)
 
 


### PR DESCRIPTION
Previously, we had a found a seg fault was being raised when trying to save out a large array.

This has now been *mostly* fixed in eccodes, but there is still an outstanding issue.
When trying to save out to GRIB, if the data is not float64, GRIB tries to cast it to float64. This is raising a seg fault!

As a temporary workaround, if we cast the data upfront, is seems to avoid the seg fault.

This PR is made up of 2 commits:
* the first commit unpins the eccodes requirements such that we get the latest eccodes, and also adds a test that explicitly tests saving int32, int64 and float32 (all of which would need casting to doubles). As you can see from the travis testng, this raises a seg fault
* the second commit adds the *temporary workaround* to cast the data to int64 upfront.

Note it turns out the seg fault was also being raised by the [TestGDT5](https://github.com/SciTools/iris-grib/blob/master/iris_grib/tests/integration/round_trip/test_grid_definition_section.py#L23) but I thought I test specific to testing the data_section would be more helpful in future, rather than  a rountripping test that just so happens to catch the issue.

This is has successfully been tested with the code that demonstrated the original seg fault from the two users who raised this. This has also been successfully tested with the iris-master tests (since there are still a couple grib-other fileformat interoperability tests.
