### PR TITLE
Allow test with latest eccodes.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,5 +2,5 @@ channels:
     - conda-forge
 dependencies:
     - iris>=2.4
-    - python-eccodes>=0.9.1,<2
+    - python-eccodes
     - pep8


### PR DESCRIPTION
Since https://github.com/SciTools/iris/issues/3723
We should now be able to fetch the "latest" version of python-eccodes from conda-forge