### PR TITLE
Correct rounding of vertical coordinates.

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -932,7 +932,7 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
         output_v = v_coord.units.convert(v_coord.points[0], output_unit)
         if output_v - abs(output_v):
             warnings.warn("Vertical level encoding problem: scaling required.")
-        output_v = int(output_v)
+        output_v = int(round(output_v))
 
         gribapi.grib_set(grib, "typeOfFirstFixedSurface", grib_v_code)
         gribapi.grib_set(grib, "scaleFactorOfFirstFixedSurface", 0)
@@ -950,9 +950,9 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
         gribapi.grib_set(grib, "scaleFactorOfFirstFixedSurface", 0)
         gribapi.grib_set(grib, "scaleFactorOfSecondFixedSurface", 0)
         gribapi.grib_set(grib, "scaledValueOfFirstFixedSurface",
-                         int(output_v[0]))
+                         int(round(output_v[0])))
         gribapi.grib_set(grib, "scaledValueOfSecondFixedSurface",
-                         int(output_v[1]))
+                         int(round(output_v[1])))
 
     if hybrid_factory is not None:
         # Need to record ALL the level coefficents in a 'PV' vector.

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -33,10 +33,10 @@ class Test(tests.IrisGribTest):
         set_fixed_surfaces(cube, grib)
         self.assertEqual(
             gribapi.grib_get_double(grib, "scaledValueOfFirstFixedSurface"),
-            304.0)
+            305.0)  # precise ~304.8
         self.assertEqual(
             gribapi.grib_get_double(grib, "scaledValueOfSecondFixedSurface"),
-            609.0)
+            610.0)  # precise ~609.6
         self.assertEqual(
             gribapi.grib_get_long(grib, "typeOfFirstFixedSurface"),
             102)


### PR DESCRIPTION
IMHO we should be rounding ***any*** time we convert a float value to a scaled integer.
See: #211
However, it looks like that is awkward and will get in the way of the 0.16 release, so I think it's not worth it now.