### PR TITLE
external grib test data skipper and hook

### DIFF
--- a/iris_grib/tests/__init__.py
+++ b/iris_grib/tests/__init__.py
@@ -35,6 +35,34 @@ _RESULT_PATH = os.path.join(os.path.dirname(__file__), 'results')
 #: Basepath for iris-grib loadable test files.
 _TESTDATA_PATH = os.path.join(os.path.dirname(__file__), 'testdata')
 
+override = os.environ.get("GRIB_TEST_DATA_PATH")
+if override:
+    if os.path.isdir(os.path.expanduser(override)):
+        _TESTDATA_PATH = os.path.abspath(override)
+
+
+def skip_data(fn):
+    """
+    Decorator to choose whether to run tests, based on the availability of
+    external data.
+
+    Example usage:
+        @skip_data
+        class MyDataTests(tests.IrisGribTest):
+            ...
+
+    """
+    no_data = (
+        not os.path.isdir(_TESTDATA_PATH)
+        or os.environ.get("GRIB_TEST_NO_DATA")
+    )
+
+    skip = unittest.skipIf(
+        condition=no_data, reason="Test(s) require external data."
+    )
+
+    return skip(fn)
+
 
 class IrisGribTest(IrisTest):
     # A specialised version of an IrisTest that implements the correct

--- a/iris_grib/tests/__init__.py
+++ b/iris_grib/tests/__init__.py
@@ -42,7 +42,7 @@ if override:
         _TESTDATA_PATH = os.path.abspath(override)
 
 
-def skip_data(fn):
+def skip_grib_data(fn):
     """
     Decorator to choose whether to run tests, based on the availability of
     external data.

--- a/iris_grib/tests/__init__.py
+++ b/iris_grib/tests/__init__.py
@@ -56,9 +56,10 @@ def skip_grib_data(fn):
     dpath = _TESTDATA_PATH
     evar = "GRIB_TEST_NO_DATA"
     no_data = not os.path.isdir(dpath) or os.environ.get(evar)
+    reason = "Test(s) require missing external GRIB test data."
 
     skip = unittest.skipIf(
-        condition=no_data, reason="Test(s) require external data."
+        condition=no_data, reason=reason
     )
 
     return skip(fn)

--- a/iris_grib/tests/__init__.py
+++ b/iris_grib/tests/__init__.py
@@ -53,10 +53,9 @@ def skip_data(fn):
             ...
 
     """
-    no_data = (
-        not os.path.isdir(_TESTDATA_PATH)
-        or os.environ.get("GRIB_TEST_NO_DATA")
-    )
+    dpath = _TESTDATA_PATH
+    evar = "GRIB_TEST_NO_DATA"
+    no_data = not os.path.isdir(dpath) or os.environ.get(evar)
 
     skip = unittest.skipIf(
         condition=no_data, reason="Test(s) require external data."

--- a/iris_grib/tests/__init__.py
+++ b/iris_grib/tests/__init__.py
@@ -16,6 +16,7 @@ import iris.tests
 import inspect
 import os
 import os.path
+import unittest
 
 import numpy as np
 

--- a/iris_grib/tests/integration/load_convert/test_load_hybrid_coords.py
+++ b/iris_grib/tests/integration/load_convert/test_load_hybrid_coords.py
@@ -17,7 +17,7 @@ from iris import load_cube, load
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 
 
-@tests.skip_data
+@tests.skip_grib_data
 class TestHybridHeight(tests.IrisGribTest):
     def setUp(self):
         filepath = self.get_testdata_path('faked_sample_hh_grib_data.grib2')
@@ -46,7 +46,7 @@ class TestHybridHeight(tests.IrisGribTest):
                                  atol=0.5)
 
 
-@tests.skip_data
+@tests.skip_grib_data
 class TestHybridPressure(tests.IrisGribTest):
     def setUp(self):
         filepath = self.get_testdata_path('faked_sample_hp_grib_data.grib2')

--- a/iris_grib/tests/integration/load_convert/test_load_hybrid_coords.py
+++ b/iris_grib/tests/integration/load_convert/test_load_hybrid_coords.py
@@ -17,6 +17,7 @@ from iris import load_cube, load
 from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 
 
+@tests.skip_data
 class TestHybridHeight(tests.IrisGribTest):
     def setUp(self):
         filepath = self.get_testdata_path('faked_sample_hh_grib_data.grib2')
@@ -45,6 +46,7 @@ class TestHybridHeight(tests.IrisGribTest):
                                  atol=0.5)
 
 
+@tests.skip_data
 class TestHybridPressure(tests.IrisGribTest):
     def setUp(self):
         filepath = self.get_testdata_path('faked_sample_hp_grib_data.grib2')

--- a/iris_grib/tests/integration/round_trip/test_WAFC_mapping_round_trip.py
+++ b/iris_grib/tests/integration/round_trip/test_WAFC_mapping_round_trip.py
@@ -17,6 +17,7 @@ from iris import load_cube, load, save
 from iris.cube import Cube
 
 
+@tests.skip_data
 class TestWAFCCodes(tests.IrisGribTest):
     def setUp(self):
         self.cat = self.get_testdata_path('CAT_T+24_0600.grib2')

--- a/iris_grib/tests/integration/round_trip/test_WAFC_mapping_round_trip.py
+++ b/iris_grib/tests/integration/round_trip/test_WAFC_mapping_round_trip.py
@@ -17,7 +17,7 @@ from iris import load_cube, load, save
 from iris.cube import Cube
 
 
-@tests.skip_data
+@tests.skip_grib_data
 class TestWAFCCodes(tests.IrisGribTest):
     def setUp(self):
         self.cat = self.get_testdata_path('CAT_T+24_0600.grib2')

--- a/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
+++ b/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
@@ -23,7 +23,7 @@ except ImportError:
     from iris.experimental.equalise_cubes import equalise_attributes
 
 
-@tests.skip_data
+@tests.skip_grib_data
 class TestHybridHeightRoundTrip(tests.IrisGribTest):
     def test_hh_round_trip(self):
         filepath = self.get_testdata_path(
@@ -42,7 +42,7 @@ class TestHybridHeightRoundTrip(tests.IrisGribTest):
             self.assertTrue(saved_cube == cube)
 
 
-@tests.skip_data
+@tests.skip_grib_data
 class TestHybridPressureRoundTrip(tests.IrisGribTest):
     def test_hybrid_pressure(self):
         filepath = self.get_testdata_path(

--- a/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
+++ b/iris_grib/tests/integration/round_trip/test_hybrid_coords_round_trip.py
@@ -23,6 +23,7 @@ except ImportError:
     from iris.experimental.equalise_cubes import equalise_attributes
 
 
+@tests.skip_data
 class TestHybridHeightRoundTrip(tests.IrisGribTest):
     def test_hh_round_trip(self):
         filepath = self.get_testdata_path(
@@ -41,6 +42,7 @@ class TestHybridHeightRoundTrip(tests.IrisGribTest):
             self.assertTrue(saved_cube == cube)
 
 
+@tests.skip_data
 class TestHybridPressureRoundTrip(tests.IrisGribTest):
     def test_hybrid_pressure(self):
         filepath = self.get_testdata_path(

--- a/iris_grib/tests/integration/save_rules/test_save_hybrid_coords.py
+++ b/iris_grib/tests/integration/save_rules/test_save_hybrid_coords.py
@@ -20,6 +20,7 @@ from iris.cube import Cube
 from iris_grib import save_pairs_from_cube, save_messages, GribMessage
 
 
+@tests.skip_data
 class TestSaveHybridHeight(tests.IrisGribTest):
     def setUp(self):
         reference_data_filepath = self.get_testdata_path('hybrid_height.nc')
@@ -80,6 +81,7 @@ class TestSaveHybridHeight(tests.IrisGribTest):
                 255)
 
 
+@tests.skip_data
 class TestSaveHybridPressure(tests.IrisGribTest):
     def setUp(self):
         reference_data_filepath = self.get_testdata_path(

--- a/iris_grib/tests/integration/save_rules/test_save_hybrid_coords.py
+++ b/iris_grib/tests/integration/save_rules/test_save_hybrid_coords.py
@@ -20,7 +20,7 @@ from iris.cube import Cube
 from iris_grib import save_pairs_from_cube, save_messages, GribMessage
 
 
-@tests.skip_data
+@tests.skip_grib_data
 class TestSaveHybridHeight(tests.IrisGribTest):
     def setUp(self):
         reference_data_filepath = self.get_testdata_path('hybrid_height.nc')
@@ -81,7 +81,7 @@ class TestSaveHybridHeight(tests.IrisGribTest):
                 255)
 
 
-@tests.skip_data
+@tests.skip_grib_data
 class TestSaveHybridPressure(tests.IrisGribTest):
     def setUp(self):
         reference_data_filepath = self.get_testdata_path(


### PR DESCRIPTION
This PR adds some simple testing infra-structure changes to support external test data.

The `iris-grib` package is not shipped with the test data within this repo, and as such, developers cannot easily test a packaged version of `iris-grib`. Note that, the tests themselves are indeed shipped with the `iris-grib` package.

This PR adds an `iris_grib.tests.skip_data` decorator and also allows developers to specify the external directory that contains the `iris-grib` data using the `GRIB_TEST_DATA_PATH` environment variable.

In addition to this, developers may also set the `GRIB_TEST_NO_DATA` environment variable to explicitly skip tests (via the `skip_data` decorator) that require said external test data.