### PR TITLE
Fix iris3 coord units

### DIFF
--- a/iris_grib/_grib1_load_rules.py
+++ b/iris_grib/_grib1_load_rules.py
@@ -238,9 +238,9 @@ def grib1_convert(grib):
     if \
             (grib.levelType == 'ml') and \
             (hasattr(grib, 'pv')):
-        aux_coords_and_dims.append((AuxCoord(grib.level, standard_name='model_level_number', attributes={'positive': 'up'}), None))
+        aux_coords_and_dims.append((AuxCoord(grib.level, standard_name='model_level_number', units=1, attributes={'positive': 'up'}), None))
         aux_coords_and_dims.append((DimCoord(grib.pv[grib.level], long_name='level_pressure', units='Pa'), None))
-        aux_coords_and_dims.append((AuxCoord(grib.pv[grib.numberOfCoordinatesValues//2 + grib.level], long_name='sigma'), None))
+        aux_coords_and_dims.append((AuxCoord(grib.pv[grib.numberOfCoordinatesValues//2 + grib.level], long_name='sigma', units=1), None))
         factories.append(Factory(HybridPressureFactory, [{'long_name': 'level_pressure'}, {'long_name': 'sigma'}, Reference('surface_pressure')]))
 
     if grib._originatingCentre != 'unknown':

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -1542,7 +1542,7 @@ def hybrid_factories(section, metadata):
             # Create the model level number scalar coordinate.
             scaledValue = section['scaledValueOfFirstFixedSurface']
             coord = DimCoord(scaledValue, standard_name='model_level_number',
-                             attributes=dict(positive='up'))
+                             units=1, attributes=dict(positive='up'))
             metadata['aux_coords_and_dims'].append((coord, None))
 
             if typeOfFirstFixedSurface == 118:
@@ -1573,7 +1573,7 @@ def hybrid_factories(section, metadata):
             metadata['aux_coords_and_dims'].append((coord, None))
             # Create the sigma scalar coordinate.
             offset = NV // 2 + scaledValue
-            coord = AuxCoord(pv[offset], long_name='sigma')
+            coord = AuxCoord(pv[offset], long_name='sigma', units=1)
             metadata['aux_coords_and_dims'].append((coord, None))
             # Create the associated factory reference.
             factory = Factory(factory_class, factory_args)
@@ -2283,19 +2283,22 @@ def satellite_common(section, metadata):
     if NB > 0:
         # Create the satellite series coordinate.
         satelliteSeries = section['satelliteSeries']
-        coord = AuxCoord(satelliteSeries, long_name='satellite_series')
+        coord = AuxCoord(satelliteSeries, long_name='satellite_series',
+                         units=1)
         # Add the satellite series coordinate to the metadata aux coords.
         metadata['aux_coords_and_dims'].append((coord, None))
 
         # Create the satellite number coordinate.
         satelliteNumber = section['satelliteNumber']
-        coord = AuxCoord(satelliteNumber, long_name='satellite_number')
+        coord = AuxCoord(satelliteNumber, long_name='satellite_number',
+                         units=1)
         # Add the satellite number coordinate to the metadata aux coords.
         metadata['aux_coords_and_dims'].append((coord, None))
 
         # Create the satellite instrument type coordinate.
         instrumentType = section['instrumentType']
-        coord = AuxCoord(instrumentType, long_name='instrument_type')
+        coord = AuxCoord(instrumentType, long_name='instrument_type',
+                         units=1)
         # Add the instrument type coordinate to the metadata aux coords.
         metadata['aux_coords_and_dims'].append((coord, None))
 

--- a/iris_grib/tests/results/integration/load_convert/data_section/TestGDT30/lambert.cml
+++ b/iris_grib/tests/results/integration/load_convert/data_section/TestGDT30/lambert.cml
@@ -15,16 +15,16 @@
         <dimCoord id="ecc4ad5a" long_name="height" points="[2.0]" shape="(1,)" units="Unit('m')" value_type="float64"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="0f43c07d" points="[-2396487.0124, -2392487.0124, -2388487.0124,
+        <dimCoord id="f429d179" points="[-2396487.0124, -2392487.0124, -2388487.0124,
 		..., 2387512.9876, 2391512.9876, 2395512.9876]" shape="(1199,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64">
-          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0.0" false_northing="0.0" secant_latitudes="(60.0, 30.0)"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="1e5b5e41" points="[-3870311.24926, -3866311.24926, -3862311.24926,
+        <dimCoord id="51f2bb31" points="[-3870311.24926, -3866311.24926, -3862311.24926,
 		..., -686311.249256, -682311.249256,
 		-678311.249256]" shape="(799,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64">
-          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0.0" false_northing="0.0" secant_latitudes="(60.0, 30.0)"/>
         </dimCoord>
       </coord>
       <coord>

--- a/iris_grib/tests/results/integration/load_convert/sample_file_loads/lambert_grib1.cml
+++ b/iris_grib/tests/results/integration/load_convert/sample_file_loads/lambert_grib1.cml
@@ -16,16 +16,16 @@
         <auxCoord id="61bde96d" long_name="originating_centre" points="[	US National Weather Service, National Centres for Environmental Prediction]" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="07a25078" points="[-2396487.0124, -2392487.0124, -2388487.0124,
+        <dimCoord id="62845c7c" points="[-2396487.0124, -2392487.0124, -2388487.0124,
 		..., 2387512.9876, 2391512.9876, 2395512.9876]" shape="(1199,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64">
-          <lambertConformal central_lat="60" central_lon="-98.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+          <lambertConformal central_lat="60.0" central_lon="-98.0" ellipsoid="GeogCS(6371229.0)" false_easting="0.0" false_northing="0.0" secant_latitudes="(60.0, 30.0)"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="fef4faee" points="[-3870311.24926, -3866311.24926, -3862311.24926,
+        <dimCoord id="c75f3634" points="[-3870311.24926, -3866311.24926, -3862311.24926,
 		..., -686311.249256, -682311.249256,
 		-678311.249256]" shape="(799,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64">
-          <lambertConformal central_lat="60" central_lon="-98.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+          <lambertConformal central_lat="60.0" central_lon="-98.0" ellipsoid="GeogCS(6371229.0)" false_easting="0.0" false_northing="0.0" secant_latitudes="(60.0, 30.0)"/>
         </dimCoord>
       </coord>
       <coord>

--- a/iris_grib/tests/results/integration/load_convert/sample_file_loads/lambert_grib2.cml
+++ b/iris_grib/tests/results/integration/load_convert/sample_file_loads/lambert_grib2.cml
@@ -15,16 +15,16 @@
         <dimCoord id="ecc4ad5a" long_name="height" points="[2.0]" shape="(1,)" units="Unit('m')" value_type="float64"/>
       </coord>
       <coord datadims="[1]">
-        <dimCoord id="0f43c07d" points="[-2396487.0124, -2392487.0124, -2388487.0124,
+        <dimCoord id="f429d179" points="[-2396487.0124, -2392487.0124, -2388487.0124,
 		..., 2387512.9876, 2391512.9876, 2395512.9876]" shape="(1199,)" standard_name="projection_x_coordinate" units="Unit('m')" value_type="float64">
-          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0.0" false_northing="0.0" secant_latitudes="(60.0, 30.0)"/>
         </dimCoord>
       </coord>
       <coord datadims="[0]">
-        <dimCoord id="1e5b5e41" points="[-3870311.24926, -3866311.24926, -3862311.24926,
+        <dimCoord id="51f2bb31" points="[-3870311.24926, -3866311.24926, -3862311.24926,
 		..., -686311.249256, -682311.249256,
 		-678311.249256]" shape="(799,)" standard_name="projection_y_coordinate" units="Unit('m')" value_type="float64">
-          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0" false_northing="0" secant_latitudes="(60.0, 30.0)"/>
+          <lambertConformal central_lat="60.0" central_lon="262.0" ellipsoid="GeogCS(6371229.0)" false_easting="0.0" false_northing="0.0" secant_latitudes="(60.0, 30.0)"/>
         </dimCoord>
       </coord>
       <coord>

--- a/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
+++ b/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
@@ -116,20 +116,17 @@ class Test_GribLevels(tests.IrisTest):
         self.assertEqual(sigma, {'long_name': 'sigma'})
         self.assertEqual(ref, Reference(name='surface_pressure'))
 
-        ml_ref = iris.coords.CoordDefn('model_level_number', None, None,
-                                       cf_units.Unit('1'),
-                                       {'positive': 'up'}, None, False)
-        lp_ref = iris.coords.CoordDefn(None, 'level_pressure', None,
-                                       cf_units.Unit('Pa'),
-                                       {}, None, False)
-        s_ref = iris.coords.CoordDefn(None, 'sigma', None,
-                                      cf_units.Unit('1'),
-                                      {}, None, False)
-
-        aux_coord_defns = [coord._as_defn() for coord, dim in results[8]]
-        self.assertIn(ml_ref, aux_coord_defns)
-        self.assertIn(lp_ref, aux_coord_defns)
-        self.assertIn(s_ref, aux_coord_defns)
+        coords_and_dims = results[8]
+        coord, = [co for co, _ in coords_and_dims
+                  if co.name() == 'model_level_number']
+        self.assertEqual(coord.units, '1')
+        self.assertEqual(coord.attributes['positive'], 'up')
+        coord, = [co for co, _ in coords_and_dims
+                  if co.name() == 'level_pressure']
+        self.assertEqual(coord.units, 'Pa')
+        coord, = [co for co, _ in coords_and_dims
+                  if co.name() == 'sigma']
+        self.assertEqual(coord.units, '1')
 
 
 if __name__ == "__main__":

--- a/iris_grib/tests/unit/load_convert/test_satellite_common.py
+++ b/iris_grib/tests/unit/load_convert/test_satellite_common.py
@@ -43,11 +43,11 @@ class Test(tests.IrisGribTest):
 
         # Check the result.
         expected = empty_metadata()
-        coord = AuxCoord(series, long_name='satellite_series')
+        coord = AuxCoord(series, long_name='satellite_series', units=1)
         expected['aux_coords_and_dims'].append((coord, None))
-        coord = AuxCoord(number, long_name='satellite_number')
+        coord = AuxCoord(number, long_name='satellite_number', units=1)
         expected['aux_coords_and_dims'].append((coord, None))
-        coord = AuxCoord(instrument, long_name='instrument_type')
+        coord = AuxCoord(instrument, long_name='instrument_type', units=1)
         expected['aux_coords_and_dims'].append((coord, None))
         standard_name = 'sensor_band_central_radiation_wavenumber'
         coord = AuxCoord(values / (10.0 ** factors),


### PR DESCRIPTION
**WIP: DO NOT MERGE**
until we have Iris3, and this is re-tested + OK

Closes #207

These changes will be needed when we release the changes on iris [default_units](https://github.com/SciTools/iris/tree/default_units)  feature-branch 
(but which is not yet merged, hence WIP flag). 
They just ensure "units=1", for unchanged behaviour when creating coords.
That is anyway benign :  it all works with current Iris.

( checked out locally, against the Iris feature-branch current content )
