### PR TITLE
Remove fix

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -1490,12 +1490,6 @@ def data_section(cube, grib):
         gribapi.grib_set(grib, "bitmapPresent", 1)
         gribapi.grib_set_double(grib, "missingValue", fill_value)
 
-    # A segmentation fault is raised by `gribapi.grib_set_double_array` if it
-    # tries to cast large data to float64. As a temporary fix we cast the data
-    # upfront
-    # TODO: remove the `astype` command once eccodes (gribapi) has been fixed.
-    if data.dtype != np.float64:
-        data = data.astype(np.float64)
     gribapi.grib_set_double_array(grib, "values", data.flatten())
 
     # todo: check packing accuracy?


### PR DESCRIPTION
**WIP**
Aiming to remove a workaround introduced in #208, supposedly now [fixed in python-eccodes](https://github.com/SciTools/iris-grib/pull/208#issuecomment-667335469).

So far, have re-checked that the original problem is replicable, having forced the old python-eccodes version, and removed the fix.  This triggered a segfault in the `tests.integration.round_trip.test_grid_definition_section.TestGDT5`.  It *should* also hit this in  `tests/unit/save_rules/test_data_section.TestNonDoubleData` (but that is not run before the crash happens).
**Then**, removed the version pin, now testing with 2.18.0 and python-eccodes 2020.06.0.
This should have been ok, but at present the original crash is still occurring .

**Current Status** : skipped out the GDT5 test, temporarily, to enable the intended test `tests/unit/save_rules/test_data_section.TestNonDoubleData`, which targets/demonstrates the problem more clearly.