### PR TITLE
Whatsnew v0.16

### DIFF
--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -77,6 +77,8 @@ Bugs Fixed
 * `@pp-mo <https://github.com/pp-mo>`_ fixed a problem that caused very slow
   loading, and possible memory overflows, with Dask versions >= 2.0.
   **This requires Iris >= 2.4**, as a new minimum dependency.
+  ( This problem was shared with UM file access in Iris : see
+  https://scitools.org.uk/iris/docs/v2.4.0/whatsnew/2.4.html#bugs-fixed ).
   `(PR#190) <https://github.com/SciTools/iris-grib/pull/190>`_
 
 * `@trexfeathers <https://github.com/trexfeathers>`_ fixed all the tests to
@@ -110,7 +112,7 @@ Dependencies
 
 * now requires Iris version >= 2.4
   Needed for the bugfix in
-  `(PR#190 <https://github.com/SciTools/iris-grib/pull/190>`_ .
+  `PR#190 <https://github.com/SciTools/iris-grib/pull/190>`_ .
 
 
 What's new in iris-grib v0.15
@@ -152,24 +154,6 @@ Dependencies
 ^^^^^^^^^^^^
 
 * Python 2 is no longer supported
-
-
-:Release: 0.15.1
-:Date: 24 Feb 2020
-
-Bug Fixes
-^^^^^^^^^
-
-* Fixed a bug that was causing all field data to be read from file during the
-  initial cube loading.  This occurred since Dask version 2.0, and caused
-  slow loading and excessive memory use.  This problem was shared with UM file
-  access in Iris : see
-  https://scitools.org.uk/iris/docs/v2.4.0/whatsnew/2.4.html#bugs-fixed .
-
-Dependencies
-^^^^^^^^^^^^
-
-* Now requires Iris version >= 2.4
 
 
 What's new in iris-grib v0.14

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -1,6 +1,117 @@
 Release Notes
 =============
 
+=======
+What's new in iris-grib v0.16
+-----------------------------
+
+:Release: 0.16.0
+:Date: ?? Sep 2020
+
+Features
+^^^^^^^^
+
+* `@tpowellmeto <https://github.com/tpowellmeto>`_ added support for loading
+  data on a "Lambert Azimuthal Equal Area Projection",
+  i.e. grid definition template 3.140.
+  See `PR#187 <https://github.com/SciTools/iris-grib/pull/187>`_ .
+
+* `@bjlittle <https://github.com/bjlittle>`_ made all the tests runnable for a
+  packaged install of iris-grib, where the grib testdata files will be missing.
+  See `PR#212 <https://github.com/SciTools/iris-grib/pull/212>`_ .
+
+* `@m1dr <https://github.com/m1dr>`_ added support for loading statistical
+  fields, as encoded in production definition template 3.8, even when the
+  "interval time increment" value is not specified (i.e. set to "missing").
+  See `PR#206 <https://github.com/SciTools/iris-grib/pull/206>`_ .
+
+* `@pp-mo <https://github.com/pp-mo>`_ ported some tests from Iris, which test
+  grib saving of data loaded from other formats.
+  See `PR#213 <https://github.com/SciTools/iris-grib/pull/213>`_ .
+  All grib-dependent testing is now contained in iris-grib : **There are no
+  remaining tests in Iris which use grib.**
+
+
+Bugs Fixed
+^^^^^^^^^^
+
+* `@lbdreyer <https://github.com/lbdreyer>`_ unpinned the python-eccodes
+  version for Travis testing, and added a workaround for a known bug in recent
+  versions of python-eccodes.
+  Previously, we could only test against python-eccodes versions ">=0.9.1,<2".
+  See `PR#208 <https://github.com/SciTools/iris-grib/pull/208>`_ .
+
+* `@pp-mo <https://github.com/pp-mo>`_ fixed save operations to round off the
+  the integer values of vertical surfaces, instead of truncating them.
+  See `PR#210 <https://github.com/SciTools/iris-grib/pull/210>`_ .
+
+* `@pp-mo <https://github.com/pp-mo>`_ fixed loading of grid definition
+  template 3.90, "Space view perspective or orthographic grid", which was
+  **broken since Iris 2.3**.  This now produces data with an iris
+  `Geostationary <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/coord_systems.html#iris.coord_systems.Geostationary>`_ 
+  coordinate system.  Prior to Iris 2.3, what is now the Iris 'Geostationary'
+  class was (incorrectly) named "VerticalPerspective" :  When that was
+  `corrected in Iris 2.3 <https://github.com/SciTools/iris/pull/3406>`_ , it
+  broke the iris-grib loading, since the data was now incorrectly
+  assigned the "new-style" Iris
+  `VerticalPerspective <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/coord_systems.html#iris.coord_systems.VerticalPerspective>`_
+  coordinate system, equivalent to the Cartopy
+  `NearsidePerspective <https://scitools.org.uk/cartopy/docs/latest/crs/projections.html#nearsideperspective>`_ 
+  and Proj
+  `"nsper" <https://proj.org/operations/projections/nsper.html>`_ .
+  The plotting behaviour of this is now **the same again as before Iris 2.3** :
+  only the Iris coordinate system has changed.
+  See `PR#223 <https://github.com/SciTools/iris-grib/pull/223>`_ .
+
+
+What's new in iris-grib v0.15.1
+-------------------------------
+
+:Release: 0.15.1
+:Date: 24 Feb 2020
+
+Bugs Fixed
+^^^^^^^^^^
+
+* `@pp-mo <https://github.com/pp-mo>`_ fixed a problem that caused very slow
+  loading, and possible memory overflows, with Dask versions >= 2.0.
+  **This requires Iris >= 2.4**, as a new minimum dependency.
+  See `PR#190 <https://github.com/SciTools/iris-grib/pull/190>`_ .
+
+* `@trexfeathers <https://github.com/trexfeathers>`_ fixed all the tests to
+  work with the latest Iris version, previously broken since Iris >= 2.3.
+  See `PR#184 <https://github.com/SciTools/iris-grib/pull/184>`_
+  and `PR#185 <https://github.com/SciTools/iris-grib/pull/185>`_ .
+
+* `@lbdreyer <https://github.com/lbdreyer>`_ fixed a problem with the metadata
+  in setup.py.
+  See `PR#183 <https://github.com/SciTools/iris-grib/pull/183>`_ .
+
+
+Internal
+^^^^^^^^
+
+* `@lbdreyer <https://github.com/lbdreyer>`_ and
+  `@pp-mo <https://github.com/pp-mo>`_ ported various grib-specific tests from
+  Iris.
+  See `PR#191 <https://github.com/SciTools/iris-grib/pull/191>`_ ,
+  `PR#192 <https://github.com/SciTools/iris-grib/pull/192>`_ ,
+  `PR#193 <https://github.com/SciTools/iris-grib/pull/193>`_ ,
+  `PR#194 <https://github.com/SciTools/iris-grib/pull/194>`_ ,
+  `PR#195 <https://github.com/SciTools/iris-grib/pull/195>`_ ,
+  `PR#198 <https://github.com/SciTools/iris-grib/pull/198>`_ ,
+  `PR#199 <https://github.com/SciTools/iris-grib/pull/199>`_ ,
+  `PR#200 <https://github.com/SciTools/iris-grib/pull/200>`_ ,
+  `PR#201 <https://github.com/SciTools/iris-grib/pull/201>`_  and
+  `PR#203 <https://github.com/SciTools/iris-grib/pull/200>`_ .
+
+Dependencies
+^^^^^^^^^^^^
+
+* now requires Iris version >= 2.4
+  Needed for the bugfix in
+  `PR#190 <https://github.com/SciTools/iris-grib/pull/190>`_ .
+
 
 What's new in iris-grib v0.15
 -----------------------------

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -14,21 +14,22 @@ Features
 * `@tpowellmeto <https://github.com/tpowellmeto>`_ added support for loading
   data on a "Lambert Azimuthal Equal Area Projection",
   i.e. grid definition template 3.140.
-  See `PR#187 <https://github.com/SciTools/iris-grib/pull/187>`_ .
+  `(PR#187) <https://github.com/SciTools/iris-grib/pull/187>`_
 
 * `@bjlittle <https://github.com/bjlittle>`_ made all the tests runnable for a
   packaged install of iris-grib, where the grib testdata files will be missing.
-  See `PR#212 <https://github.com/SciTools/iris-grib/pull/212>`_ .
+  `(PR#212) <https://github.com/SciTools/iris-grib/pull/212>`_
 
 * `@m1dr <https://github.com/m1dr>`_ added support for loading statistical
   fields, as encoded in production definition template 3.8, even when the
   "interval time increment" value is not specified (i.e. set to "missing").
-  See `PR#206 <https://github.com/SciTools/iris-grib/pull/206>`_ .
+  `(PR#206) <https://github.com/SciTools/iris-grib/pull/206>`_
 
 * `@pp-mo <https://github.com/pp-mo>`_ ported some tests from Iris, which test
   grib saving of data loaded from other formats.
-  See `PR#213 <https://github.com/SciTools/iris-grib/pull/213>`_ .
-  All grib-dependent testing is now contained in iris-grib : **There are no
+  `(PR#213) <https://github.com/SciTools/iris-grib/pull/213>`_
+
+* All grib-dependent testing is now contained in iris-grib : **There are no
   remaining tests in Iris which use grib.**
 
 
@@ -39,11 +40,11 @@ Bugs Fixed
   version for Travis testing, and added a workaround for a known bug in recent
   versions of python-eccodes.
   Previously, we could only test against python-eccodes versions ">=0.9.1,<2".
-  See `PR#208 <https://github.com/SciTools/iris-grib/pull/208>`_ .
+  `(PR#208) <https://github.com/SciTools/iris-grib/pull/208>`_
 
 * `@pp-mo <https://github.com/pp-mo>`_ fixed save operations to round off the
   the integer values of vertical surfaces, instead of truncating them.
-  See `PR#210 <https://github.com/SciTools/iris-grib/pull/210>`_ .
+  `(PR#210) <https://github.com/SciTools/iris-grib/pull/210>`_
 
 * `@pp-mo <https://github.com/pp-mo>`_ fixed loading of grid definition
   template 3.90, "Space view perspective or orthographic grid", which was
@@ -61,7 +62,7 @@ Bugs Fixed
   `"nsper" <https://proj.org/operations/projections/nsper.html>`_ .
   The plotting behaviour of this is now **the same again as before Iris 2.3** :
   only the Iris coordinate system has changed.
-  See `PR#223 <https://github.com/SciTools/iris-grib/pull/223>`_ .
+  `(PR#223) <https://github.com/SciTools/iris-grib/pull/223>`_
 
 
 What's new in iris-grib v0.15.1
@@ -76,16 +77,16 @@ Bugs Fixed
 * `@pp-mo <https://github.com/pp-mo>`_ fixed a problem that caused very slow
   loading, and possible memory overflows, with Dask versions >= 2.0.
   **This requires Iris >= 2.4**, as a new minimum dependency.
-  See `PR#190 <https://github.com/SciTools/iris-grib/pull/190>`_ .
+  `(PR#190) <https://github.com/SciTools/iris-grib/pull/190>`_
 
 * `@trexfeathers <https://github.com/trexfeathers>`_ fixed all the tests to
   work with the latest Iris version, previously broken since Iris >= 2.3.
-  See `PR#184 <https://github.com/SciTools/iris-grib/pull/184>`_
-  and `PR#185 <https://github.com/SciTools/iris-grib/pull/185>`_ .
+  `(PR#184) <https://github.com/SciTools/iris-grib/pull/184>`_
+  and `(PR#185) <https://github.com/SciTools/iris-grib/pull/185>`_
 
 * `@lbdreyer <https://github.com/lbdreyer>`_ fixed a problem with the metadata
   in setup.py.
-  See `PR#183 <https://github.com/SciTools/iris-grib/pull/183>`_ .
+  `(PR#183) <https://github.com/SciTools/iris-grib/pull/183>`_
 
 
 Internal
@@ -94,23 +95,22 @@ Internal
 * `@lbdreyer <https://github.com/lbdreyer>`_ and
   `@pp-mo <https://github.com/pp-mo>`_ ported various grib-specific tests from
   Iris.
-  See `PR#191 <https://github.com/SciTools/iris-grib/pull/191>`_ ,
+  ( `PR#191 <https://github.com/SciTools/iris-grib/pull/191>`_ ,
   `PR#192 <https://github.com/SciTools/iris-grib/pull/192>`_ ,
-  `PR#193 <https://github.com/SciTools/iris-grib/pull/193>`_ ,
   `PR#194 <https://github.com/SciTools/iris-grib/pull/194>`_ ,
   `PR#195 <https://github.com/SciTools/iris-grib/pull/195>`_ ,
   `PR#198 <https://github.com/SciTools/iris-grib/pull/198>`_ ,
   `PR#199 <https://github.com/SciTools/iris-grib/pull/199>`_ ,
   `PR#200 <https://github.com/SciTools/iris-grib/pull/200>`_ ,
   `PR#201 <https://github.com/SciTools/iris-grib/pull/201>`_  and
-  `PR#203 <https://github.com/SciTools/iris-grib/pull/200>`_ .
+  `PR#203 <https://github.com/SciTools/iris-grib/pull/203>`_ )
 
 Dependencies
 ^^^^^^^^^^^^
 
 * now requires Iris version >= 2.4
   Needed for the bugfix in
-  `PR#190 <https://github.com/SciTools/iris-grib/pull/190>`_ .
+  `(PR#190 <https://github.com/SciTools/iris-grib/pull/190>`_ .
 
 
 What's new in iris-grib v0.15


### PR DESCRIPTION
Writeups for changes since 0.15.0, since we don't seem to have updated the whatsnew with 0.15.1 changes.
This is intended to be almost-ready for release, but...
  * I am assuming that #223 is going in
  * the actual release date will need writing in

I have tried to use style closer to the newer Iris whatsnews.  
Please highlight if more could be done in that way.

**temporary docs-build can be viewed [here](https://pp-iris-grib.readthedocs.io/en/whatsnew_16/ref/release_notes.html)**