### PR TITLE
Version 0.16 release candidate

### DIFF
--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -64,6 +64,14 @@ Bugs Fixed
   only the Iris coordinate system has changed.
   `(PR#223) <https://github.com/SciTools/iris-grib/pull/223>`_
 
+Dependencies
+^^^^^^^^^^^^
+
+* now requires Iris version >= 3.0
+  Needed for the bugfix in
+  `PR#223 <https://github.com/SciTools/iris-grib/pull/223>`_ .
+
+
 
 What's new in iris-grib v0.15.1
 -------------------------------

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -33,7 +33,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.15.1'
+__version__ = '0.16.0rc0'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -1,7 +1,7 @@
 name: iris-grib-dev
 
 channels:
-  - conda-forge
+  - conda-forge/label/rc_iris
 
 dependencies:
   - python=3.6
@@ -10,7 +10,7 @@ dependencies:
   - setuptools
 
 # Core dependencies.
-  - iris>=2.4
+  - iris=3.0.0rc0
   - python-eccodes
 
 # Optional dependencies.

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -1,7 +1,7 @@
 name: iris-grib-dev
 
 channels:
-  - conda-forge
+  - conda-forge/label/rc_iris
 
 dependencies:
   - python=3.7
@@ -10,7 +10,7 @@ dependencies:
   - setuptools
 
 # Core dependencies.
-  - iris>=2.4
+  - iris=3.0.0rc0
   - python-eccodes
 
 # Optional dependencies.

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
 # Core dependencies.
 
-scitools-iris>=3.0
+scitools-iris>=3.0.0rc0
 eccodes-python

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
 # Core dependencies.
 
-scitools-iris>=2.4
+scitools-iris>=3.0
 eccodes-python


### PR DESCRIPTION
Now basing this against the release branch "0.16.x", which is branched from the feature branch "f__test-iris-master"

This PR now modifies that to specifically test against the Iris 3.0.0rc0 release-candidate from `conda-forge/iris_rc`
The changes here are specific to the 0.16 release and will ***not*** go back onto master.
