### PR TITLE
Cosmetic change : rename the travis iris-test-version options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ dist: xenial
 
 env:
   matrix:
-    - PYTHON_VERSION=36 LIMIT_TO_RELEASED_IRIS=false
-    - PYTHON_VERSION=37 LIMIT_TO_RELEASED_IRIS=false
-  #  - PYTHON_VERSION=36 LIMIT_TO_RELEASED_IRIS=true
-  #  - PYTHON_VERSION=37 LIMIT_TO_RELEASED_IRIS=true
+    - PYTHON_VERSION=36 IRIS_VERSION=master
+    - PYTHON_VERSION=37 IRIS_VERSION=master
+    - PYTHON_VERSION=36 IRIS_VERSION=release
+    - PYTHON_VERSION=37 IRIS_VERSION=release
 
 install:
   # Download iris-test-data
@@ -42,10 +42,10 @@ install:
     export ENV_NAME="iris-grib-dev";
     export ENV_FILE="${TRAVIS_BUILD_DIR}/requirements/ci/py${PYTHON_VERSION}.yml";
 
-  # Optionally download latest Iris from repo,
+  # Optionally download latest Iris master, from the github repo,
   # and replace the Iris dependency with Iris' underlying dependencies.
   - >
-    if [[ "${LIMIT_TO_RELEASED_IRIS}" == false ]]; then
+    if [[ "${IRIS_VERSION}" == "master" ]]; then
       IRIS_REF="https://github.com/SciTools/iris/archive/master.zip";
       export IRIS_LOCATION="${HOME}/iris";
       mkdir ${IRIS_LOCATION};
@@ -79,9 +79,9 @@ install:
   # --------------
   - echo "Configuring Iris";
 
-  # Optionally install latest Iris from downloaded source.
+  # Optionally install latest Iris master, from downloaded source.
   - >
-    if [[ "${LIMIT_TO_RELEASED_IRIS}" == false ]]; then
+    if [[ "${IRIS_VERSION}" == "master" ]]; then
       cd ${IRIS_LOCATION}/iris-master;
       python setup.py --quiet install;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ dist: xenial
 
 env:
   matrix:
-    - PYTHON_VERSION=36 IRIS_VERSION=master
-    - PYTHON_VERSION=37 IRIS_VERSION=master
-    - PYTHON_VERSION=36 IRIS_VERSION=release
-    - PYTHON_VERSION=37 IRIS_VERSION=release
+    - PYTHON_VERSION=36 IRIS_SOURCE=master
+    - PYTHON_VERSION=37 IRIS_SOURCE=master
+    - PYTHON_VERSION=36 IRIS_SOURCE=release
+    - PYTHON_VERSION=37 IRIS_SOURCE=release
 
 install:
   # Download iris-test-data
@@ -45,7 +45,7 @@ install:
   # Optionally download latest Iris master, from the github repo,
   # and replace the Iris dependency with Iris' underlying dependencies.
   - >
-    if [[ "${IRIS_VERSION}" == "master" ]]; then
+    if [[ "${IRIS_SOURCE}" == "master" ]]; then
       IRIS_REF="https://github.com/SciTools/iris/archive/master.zip";
       export IRIS_LOCATION="${HOME}/iris";
       mkdir ${IRIS_LOCATION};
@@ -81,7 +81,7 @@ install:
 
   # Optionally install latest Iris master, from downloaded source.
   - >
-    if [[ "${IRIS_VERSION}" == "master" ]]; then
+    if [[ "${IRIS_SOURCE}" == "master" ]]; then
       cd ${IRIS_LOCATION}/iris-master;
       python setup.py --quiet install;
     fi;


### PR DESCRIPTION
Rename Iris test-version options, and enable all to check action.

This will also demonstrate testing against latest release
  -- but then some tests will fail

When we get to merge this F-B back, it is because we have an actual Iris 3.0 release.
In that case, this should start to work.