### PR TITLE
Add 'main' conda-forge channel, needed for docs builds.

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -342,55 +342,22 @@ class GribWrapper:
         self.extra_keys['_forecastTimeUnit'] = self._timeunit_string()
 
         # shape of the earth
-
-        # pre-defined sphere
-        if self.shapeOfTheEarth == 0:
+        soe_code = self.shapeOfTheEarth
+        # As this class is now *only* for GRIB1, 'shapeOfTheEarth' is not a value read from the actual file :  It is
+        # really a GRIB2 param, and the value is merely what eccodes (griabpi) considers the correct default.
+        # This was always =6 until eccodes 0.19, when it changed to 0.  See https://jira.ecmwf.int/browse/ECC-811
+        # The two represent different sized spherical earths.
+        if soe_code not in (6, 0):
+            raise ValueError('Unexpected shapeOfTheEarth value =', soe_code)
+        # *FOR NOW* maintain the old behaviour (radius=6371229) in all cases for backwards compatibility.
+        # However, this does not match 'radiusOfTheEarth' and may be incorrect :  We may change it in future.
+        soe_code = 6
+        if soe_code == 0:
+            # New supposedly-correct correct value, matches the 'radiusOfTheEarth' parameter.
             geoid = coord_systems.GeogCS(semi_major_axis=6367470)
-
-        # custom sphere
-        elif self.shapeOfTheEarth == 1:
-            geoid = coord_systems.GeogCS(
-                self.scaledValueOfRadiusOfSphericalEarth *
-                10 ** -self.scaleFactorOfRadiusOfSphericalEarth)
-
-        # IAU65 oblate sphere
-        elif self.shapeOfTheEarth == 2:
-            geoid = coord_systems.GeogCS(6378160, inverse_flattening=297.0)
-
-        # custom oblate spheroid (km)
-        elif self.shapeOfTheEarth == 3:
-            geoid = coord_systems.GeogCS(
-                semi_major_axis=self.scaledValueOfEarthMajorAxis *
-                10 ** -self.scaleFactorOfEarthMajorAxis * 1000.,
-                semi_minor_axis=self.scaledValueOfEarthMinorAxis *
-                10 ** -self.scaleFactorOfEarthMinorAxis * 1000.)
-
-        # IAG-GRS80 oblate spheroid
-        elif self.shapeOfTheEarth == 4:
-            geoid = coord_systems.GeogCS(6378137, None, 298.257222101)
-
-        # WGS84
-        elif self.shapeOfTheEarth == 5:
-            geoid = \
-                coord_systems.GeogCS(6378137, inverse_flattening=298.257223563)
-
-        # pre-defined sphere
-        elif self.shapeOfTheEarth == 6:
+        elif soe_code == 6:
+            # Old value, does *not* match the 'radiusOfTheEarth' parameter.
             geoid = coord_systems.GeogCS(6371229)
-
-        # custom oblate spheroid (m)
-        elif self.shapeOfTheEarth == 7:
-            geoid = coord_systems.GeogCS(
-                semi_major_axis=self.scaledValueOfEarthMajorAxis *
-                10 ** -self.scaleFactorOfEarthMajorAxis,
-                semi_minor_axis=self.scaledValueOfEarthMinorAxis *
-                10 ** -self.scaleFactorOfEarthMinorAxis)
-
-        elif self.shapeOfTheEarth == 8:
-            raise ValueError("unhandled shape of earth : grib earth shape = 8")
-
-        else:
-            raise ValueError("undefined shape of earth")
 
         gridType = gribapi.grib_get_string(self.grib_message, "gridType")
 

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -343,17 +343,24 @@ class GribWrapper:
 
         # shape of the earth
         soe_code = self.shapeOfTheEarth
-        # As this class is now *only* for GRIB1, 'shapeOfTheEarth' is not a value read from the actual file :  It is
-        # really a GRIB2 param, and the value is merely what eccodes (griabpi) considers the correct default.
-        # This was always =6 until eccodes 0.19, when it changed to 0.  See https://jira.ecmwf.int/browse/ECC-811
+        # As this class is now *only* for GRIB1, 'shapeOfTheEarth' is not a
+        # value read from the actual file :  It is really a GRIB2 param, and
+        # the value is merely what eccodes (gribapi) gives as the default.
+        # This was always = 6, until eccodes 0.19, when it changed to 0.
+        # See https://jira.ecmwf.int/browse/ECC-811
         # The two represent different sized spherical earths.
         if soe_code not in (6, 0):
             raise ValueError('Unexpected shapeOfTheEarth value =', soe_code)
-        # *FOR NOW* maintain the old behaviour (radius=6371229) in all cases for backwards compatibility.
-        # However, this does not match 'radiusOfTheEarth' and may be incorrect :  We may change it in future.
+
         soe_code = 6
+        # *FOR NOW* maintain the old behaviour (radius=6371229) in all cases,
+        # for backwards compatibility.
+        # However, this does not match the 'radiusOfTheEarth' default from the
+        # gribapi so is probably incorrect (see above issue ECC-811).
+        # So we may change this in future.
+
         if soe_code == 0:
-            # New supposedly-correct correct value, matches the 'radiusOfTheEarth' parameter.
+            # New supposedly-correct default value, matches 'radiusOfTheEarth'.
             geoid = coord_systems.GeogCS(semi_major_axis=6367470)
         elif soe_code == 6:
             # Old value, does *not* match the 'radiusOfTheEarth' parameter.

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -2,6 +2,7 @@ name: iris-grib-dev
 
 channels:
   - conda-forge/label/rc_iris
+  - conda-forge
 
 dependencies:
   - python=3.6

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -2,6 +2,7 @@ name: iris-grib-dev
 
 channels:
   - conda-forge/label/rc_iris
+  - conda-forge
 
 dependencies:
   - python=3.7


### PR DESCRIPTION
This fixes the RTD docs-build error which emerged following the cut of the original 0.16.0rc0 pre-release tag.

Given the error seen in the attempt to re-spin #224 today, we suspect those errors will come through here too
(something to do with ellipsoid definitions changing)
So we will probably want to wait until that is fixed before merging this ...