### PR TITLE
add missing test dependency

### DIFF
--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -20,3 +20,4 @@ dependencies:
   - mock
   - filelock
   - pep8
+  - requests

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -20,3 +20,4 @@ dependencies:
   - mock
   - filelock
   - pep8
+  - requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,4 @@
 mock
 filelock
 pep8
+requests


### PR DESCRIPTION
This PR adds a missing test dependency that is expected by `iris` when testing.

Typically a developer will already have this available when testing against a development version of `iris`, but the `requests` package is not pulled in by `iris-grib` when installing `iris` from `conda-forge`.