### PR TITLE
update readme badge for cirrus-ci

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 iris-grib
 =========
 
-|Travis|_ |Coveralls|_
+|CirrusCI|_ |Coveralls|_
 
 GRIB interface for `Iris <https://github.com/SciTools/iris>`_.
 
@@ -17,10 +17,10 @@ Copyright and licence
 iris-grib may be freely distributed, modified and used commercially under the
 terms of its `GNU LGPLv3 license <COPYING.LESSER>`_.
 
-\(C) British Crown Copyright 2010 - 2020, Met Office
+\(C) British Crown Copyright 2010 - 2021, Met Office
 
-.. |Travis| image:: https://travis-ci.org/SciTools/iris-grib.svg?branch=master
-.. _Travis: https://travis-ci.org/SciTools/iris-grib
+.. |CirrusCI| image:: https://api.cirrus-ci.com/github/SciTools/iris-grib.svg?branch=master
+.. _CirrusCI: https://cirrus-ci.com/github/SciTools/iris-grib
 
 .. |Coveralls| image:: https://coveralls.io/repos/github/SciTools/iris-grib/badge.svg?branch=master
 .. _Coveralls: https://coveralls.io/github/SciTools/iris-grib?branch=master 


### PR DESCRIPTION
This PR updates the `README.rst` build badge to use `cirrus-ci` instead of `travis-ci`.