### PR TITLE
Add support for reg 92.1.8 where lon increment not given

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -487,12 +487,13 @@ def ellipsoid_geometry(section):
     return major, minor, radius
 
 
-def _calculate_increment(first_grid_point, last_grid_point, num_intervals):
-    # Calculates the directional increment from the difference between
-    # the grid point values divided by the total number of intervals.
-    # Required by template 0 & 40 when no increment values are provided.
-
-    return math.fabs(last_grid_point - first_grid_point) / num_intervals
+def _calculate_increment(first_point, last_point, n_increments, mod=math.inf):
+    """
+    Calculates the directional increment from the difference between the grid
+    point values divided by the total number of increments. Required by
+    template 0 & 40 when no increment values are provided.
+    """
+    return (last_point - first_point) % mod / n_increments
 
 
 def grid_definition_template_0_and_1(section, metadata, y_name, x_name, cs):
@@ -538,7 +539,8 @@ def grid_definition_template_0_and_1(section, metadata, y_name, x_name, cs):
              if res_flags.i_increments_given
              else _calculate_increment(section['longitudeOfFirstGridPoint'],
                                        section['longitudeOfLastGridPoint'],
-                                       section['Ni'] - 1))
+                                       section['Ni'] - 1,
+                                       360.0 / _GRID_ACCURACY_IN_DEGREES))
     x_inc *= _GRID_ACCURACY_IN_DEGREES
     x_offset = section['longitudeOfFirstGridPoint'] * _GRID_ACCURACY_IN_DEGREES
     x_direction = -1 if scan.i_negative else 1
@@ -1071,7 +1073,8 @@ def grid_definition_template_40_regular(section, metadata, cs):
              if res_flags.i_increments_given
              else _calculate_increment(section['longitudeOfFirstGridPoint'],
                                        section['longitudeOfLastGridPoint'],
-                                       section['Ni'] - 1))
+                                       section['Ni'] - 1,
+                                       360.0 / _GRID_ACCURACY_IN_DEGREES))
     x_inc *= _GRID_ACCURACY_IN_DEGREES
     x_offset = section['longitudeOfFirstGridPoint'] * _GRID_ACCURACY_IN_DEGREES
     x_direction = -1 if scan.i_negative else 1

--- a/iris_grib/tests/unit/load_convert/test_calculate_increment.py
+++ b/iris_grib/tests/unit/load_convert/test_calculate_increment.py
@@ -24,6 +24,10 @@ class Test(tests.IrisGribTest):
         result = _calculate_increment(-5, 5, 10)
         self.assertEqual(result, 1)
 
+    def test_with_mod(self):
+        result = _calculate_increment(355, 5, 10, 360)
+        self.assertEqual(result, 1)
+
 
 if __name__ == '__main__':
     tests.main()

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_0_and_1.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_0_and_1.py
@@ -49,18 +49,17 @@ class Test_resolution_flags(tests.IrisGribTest):
         })
         return section
 
-    def expected(self, x_dim, y_dim, x_neg=True, y_neg=True):
+    def expected(self, x_dim, y_dim, x_points, y_points, x_neg=True,
+                 y_neg=True):
         # Prepare the expectation.
         expected = empty_metadata()
         cs = iris.coord_systems.GeogCS(6367470)
-        x_points = np.array([0., 1., 2., 3., 4., 5.])
         if x_neg:
             x_points = x_points[::-1]
         x = iris.coords.DimCoord(x_points,
                                  standard_name='longitude',
                                  units='degrees',
                                  coord_system=cs)
-        y_points = np.array([0., 1., 2., 3., 4., 5.])
         if y_neg:
             y_points = y_points[::-1]
         y = iris.coords.DimCoord(y_points,
@@ -77,7 +76,10 @@ class Test_resolution_flags(tests.IrisGribTest):
         cs = iris.coord_systems.GeogCS(6367470)
         grid_definition_template_0_and_1(section, metadata, 'latitude',
                                          'longitude', cs)
-        expected = self.expected(1, 0, x_neg=False, y_neg=False)
+        x_points = np.array([0., 1., 2., 3., 4., 5.])
+        y_points = np.array([0., 1., 2., 3., 4., 5.])
+        expected = self.expected(1, 0, x_points, y_points, x_neg=False,
+                                 y_neg=False)
         self.assertEqual(metadata, expected)
 
     def test_with_increments(self):
@@ -89,7 +91,10 @@ class Test_resolution_flags(tests.IrisGribTest):
         cs = iris.coord_systems.GeogCS(6367470)
         grid_definition_template_0_and_1(section, metadata, 'latitude',
                                          'longitude', cs)
-        expected = self.expected(1, 0, x_neg=False, y_neg=False)
+        x_points = np.array([0., 1., 2., 3., 4., 5.])
+        y_points = np.array([0., 1., 2., 3., 4., 5.])
+        expected = self.expected(1, 0, x_points, y_points, x_neg=False,
+                                 y_neg=False)
         self.assertEqual(metadata, expected)
 
     def test_with_i_not_j_increment(self):
@@ -100,7 +105,10 @@ class Test_resolution_flags(tests.IrisGribTest):
         cs = iris.coord_systems.GeogCS(6367470)
         grid_definition_template_0_and_1(section, metadata, 'latitude',
                                          'longitude', cs)
-        expected = self.expected(1, 0, x_neg=False, y_neg=False)
+        x_points = np.array([0., 1., 2., 3., 4., 5.])
+        y_points = np.array([0., 1., 2., 3., 4., 5.])
+        expected = self.expected(1, 0, x_points, y_points, x_neg=False,
+                                 y_neg=False)
         self.assertEqual(metadata, expected)
 
     def test_with_j_not_i_increment(self):
@@ -111,7 +119,26 @@ class Test_resolution_flags(tests.IrisGribTest):
         cs = iris.coord_systems.GeogCS(6367470)
         grid_definition_template_0_and_1(section, metadata, 'latitude',
                                          'longitude', cs)
-        expected = self.expected(1, 0, x_neg=False, y_neg=False)
+        x_points = np.array([0., 1., 2., 3., 4., 5.])
+        y_points = np.array([0., 1., 2., 3., 4., 5.])
+        expected = self.expected(1, 0, x_points, y_points, x_neg=False,
+                                 y_neg=False)
+        self.assertEqual(metadata, expected)
+
+    def test_without_increments_crossing_0_lon(self):
+        section = self.section_3()
+        section['longitudeOfFirstGridPoint'] = 355000000
+        section['Ni'] = 11
+        metadata = empty_metadata()
+        cs = iris.coord_systems.GeogCS(6367470)
+        grid_definition_template_0_and_1(section, metadata, 'latitude',
+                                         'longitude', cs)
+        x_points = np.array(
+            [355., 356., 357., 358., 359., 360., 361., 362., 363., 364., 365.]
+        )
+        y_points = np.array([0., 1., 2., 3., 4., 5.])
+        expected = self.expected(1, 0, x_points, y_points, x_neg=False,
+                                 y_neg=False)
         self.assertEqual(metadata, expected)
 
 


### PR DESCRIPTION
Per regulation 92.1.8, longitudes are limited to the range 0 to 360 degrees. This PR adds support for calculating `iDirectionIncrement` when not given (i.e. `resolutionAndComponentFlags` bit 3 is 0) where `longitudeOfFirstGridPoint` and `longitudeOfLastGridPoint` span the prime meridian in GDTs 0 and 40 and siblings.