### PR TITLE
conda workaround in cirrus-ci for bad linux kernel version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,7 +69,9 @@ linux_task_template: &LINUX_TASK_TEMPLATE
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(sha256sum miniconda.sh)"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${CONDA_CACHE_BUILD}"
+      - uname -r
     populate_script:
+      - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
       - conda config --set show_channel_urls True
@@ -103,4 +105,5 @@ tests_task:
   name: "${CIRRUS_OS}: py${PY_VER} tests"
   << : *LINUX_TASK_TEMPLATE
   tests_script:
+    - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
     - nox --session tests -- --test-data-dir ${IRIS_TEST_DATA_DIR}/test_data


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/conda/conda/issues/10596, as a workaround.