### PR TITLE
Add data template number 42 to the list of supported templates

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -2515,7 +2515,7 @@ def data_representation_section(section):
     template = section['dataRepresentationTemplateNumber']
 
     # Supported templates for both grid point and spectral data:
-    grid_point_templates = (0, 1, 2, 3, 4, 40, 41, 61)
+    grid_point_templates = (0, 1, 2, 3, 4, 40, 41, 42, 61)
     spectral_templates = (50, 51)
     supported_templates = grid_point_templates + spectral_templates
 

--- a/iris_grib/tests/unit/load_convert/test_data_representation_section.py
+++ b/iris_grib/tests/unit/load_convert/test_data_representation_section.py
@@ -1,0 +1,38 @@
+# Copyright iris-grib contributors
+#
+# This file is part of iris-grib and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Test function :func:`iris_grib._load_convert.data_representation_section.`
+
+"""
+
+# import iris_grib.tests first so that some things can be initialised
+# before importing anything else.
+import iris_grib.tests as tests
+
+from iris.exceptions import TranslationError
+
+from iris_grib._load_convert import data_representation_section
+from iris_grib.tests.unit import _make_test_message
+
+
+class Test(tests.IrisGribTest):
+    def test_supported_templates(self):
+        template_nums = [0, 1, 2, 3, 4, 40, 41, 42, 50, 51, 61]
+        for template_num in template_nums:
+            message = _make_test_message(
+                {5: {'dataRepresentationTemplateNumber': template_num}})
+            data_representation_section(message.sections[5])
+
+    def test_unsupported_template(self):
+        message = _make_test_message(
+            {5: {'dataRepresentationTemplateNumber': 5}})
+        err_msg = 'Data Representation Section Template [5] is not supported'
+        with self.assertRaisesRegex(TranslationError, err_msg):
+            data_representation_section(message.sections[5])
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/iris_grib/tests/unit/load_convert/test_data_representation_section.py
+++ b/iris_grib/tests/unit/load_convert/test_data_representation_section.py
@@ -29,7 +29,7 @@ class Test(tests.IrisGribTest):
     def test_unsupported_template(self):
         message = _make_test_message(
             {5: {'dataRepresentationTemplateNumber': 5}})
-        err_msg = 'Data Representation Section Template [5] is not supported'
+        err_msg = 'Template [5] is not supported'
         with self.assertRaisesRegex(TranslationError, err_msg):
             data_representation_section(message.sections[5])
 

--- a/iris_grib/tests/unit/load_convert/test_data_representation_section.py
+++ b/iris_grib/tests/unit/load_convert/test_data_representation_section.py
@@ -29,7 +29,7 @@ class Test(tests.IrisGribTest):
     def test_unsupported_template(self):
         message = _make_test_message(
             {5: {'dataRepresentationTemplateNumber': 5}})
-        err_msg = 'Template [5] is not supported'
+        err_msg = r'Template \[5\] is not supported'
         with self.assertRaisesRegex(TranslationError, err_msg):
             data_representation_section(message.sections[5])
 


### PR DESCRIPTION
We recently had a user who wanted to load in data with grib data template number 42, i.e. CCSDS with compression, which we currently do not support.

The data decompression is all done in eccodes, so all we need to get this new template working is
* ensure we have a build of eccodes which was built with AEC enabled (the conda-forge build of eccodes [already has this enabled](https://github.com/conda-forge/eccodes-feedstock/blob/master/recipe/build.sh#L33)),
* add `42` to the list of supported template numbers
then when iris-grib loads in the data from the grib file, it goes via eccodes, which handles the decompresssion, and so returns a numpy array as normal.

I have kept the code change to iris-grib very lightweight (so I didn't check that the eccodes version running was built with AEC enabled) as all the handling of the data is performed by eccodes so we should just hand that off to eccodes.
If you're interested. if you try to run my branch in an env without AEC, you get the following error:
```
ECCODES ERROR   :  grib_accessor_data_ccsds_packing: CCSDS support not enabled. Please rebuild with -DENABLE_AEC=ON (Adaptive Entropy Coding library)
Traceback (most recent call last):
  File "something.py", line 42, in <module>
    print(cube.data[0,0])
 ...
  File ".../lib/python3.7/site-packages/iris_grib/message.py", line 444, in _get_key_value
    res = gribapi.grib_get_array(self._message_id, key)
  File ".../lib/python3.7/site-packages/gribapi/gribapi.py", line 1958, in grib_get_array
    result = grib_get_double_array(msgid, key)
  File ".../lib/python3.7/site-packages/gribapi/gribapi.py", line 1170, in grib_get_double_array
    GRIB_CHECK(err)
  File ".../lib/python3.7/site-packages/gribapi/gribapi.py", line 225, in GRIB_CHECK
    errors.raise_grib_error(errid)
  File ".../lib/python3.7/site-packages/gribapi/errors.py", line 382, in raise_grib_error
    raise ERROR_MAP[errid](errid)
gribapi.errors.FunctionalityNotEnabledError: Functionality not enabled
```
which is informative enough. I have decided against catching this error in a try/except block and instead putting out our own error. That seems unnecessary.

As for tests I have followed a similarly lightweight approach. As all we're doing in iris-grib is checking the template number against a list of known supported templates, all I've done is test this. I haven't tested that what eccodes returns to us is correctly decompressed data as that should be tested by eccodes.

