### PR TITLE
Add release notes and update version number

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'iris-grib'
-copyright = u'2016, Met Office'
+copyright = u'2021, Met Office'
 author = u'Met Office'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Iris-grib v0.16
+Iris-grib v0.17
 ===============
 
 The library ``iris-grib`` provides functionality for converting between weather and

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -2,6 +2,33 @@ Release Notes
 =============
 
 
+What's new in iris-grib v0.17
+-----------------------------
+
+:Release: 0.17.0
+:Date: 18 May 2021
+
+Features
+^^^^^^^^
+
+* `@m1dr <https://github.com/m1dr>`_ added support for GRIB regulation 92.1.8 
+  for loading GRIB files where the longitude increment is not given.
+  `(PR#261) <https://github.com/SciTools/iris-grib/pull/261>`_
+
+* `@lbdreyer <https://github.com/lbdreyer>`_ added support for loading Grid 
+  point and spectral data with CCSDS recommended lossless compression, i.e. 
+  data representation template 42
+  `(PR#264) <https://github.com/SciTools/iris-grib/pull/264>`_
+
+
+Internal
+^^^^^^^^
+
+* `@jamesp <https://github.com/jamesp>`_ moved CI testing to Cirrus CI
+  `(PR#250) <https://github.com/SciTools/iris-grib/pull/250>`_
+
+
+
 What's new in iris-grib v0.16
 -----------------------------
 

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -15,16 +15,16 @@ Features
   for loading GRIB files where the longitude increment is not given.
   `(PR#261) <https://github.com/SciTools/iris-grib/pull/261>`_
 
-* `@lbdreyer <https://github.com/lbdreyer>`_ added support for loading Grid 
+* `@lbdreyer <https://github.com/lbdreyer>`_ added support for loading grid 
   point and spectral data with CCSDS recommended lossless compression, i.e. 
-  data representation template 42
+  data representation template 42.
   `(PR#264) <https://github.com/SciTools/iris-grib/pull/264>`_
 
 
 Internal
 ^^^^^^^^
 
-* `@jamesp <https://github.com/jamesp>`_ moved CI testing to Cirrus CI
+* `@jamesp <https://github.com/jamesp>`_ moved CI testing to Cirrus CI.
   `(PR#250) <https://github.com/SciTools/iris-grib/pull/250>`_
 
 

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -33,7 +33,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.17.dev0'
+__version__ = '0.17.0'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']


### PR DESCRIPTION
Following the same pattern as was done in #244 

This:
* updates the release notes to include the 0.17 release, and
* updates the version string.

Regarding the release notes, I haven't included *every* PR. I skipped #258, #259, #262 as they all seemed a bit to minor to include

Readthedocs build: https://iris-grib.readthedocs.io/en/doctest_0v17/
