### PR TITLE
Blocked: Fix nox when HOME not set

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,10 @@ PY_VER = os.environ.get("PY_VER", ["3.6", "3.7"])
 IRIS_SOURCE = os.environ.get("IRIS_SOURCE", ['source', 'conda-forge'])
 
 #: Default cartopy cache directory.
-CARTOPY_CACHE_DIR = os.environ.get("HOME") / Path(".local/share/cartopy")
+if os.getenv("HOME"):
+    CARTOPY_CACHE_DIR = Path(os.getenv("HOME")) / ".local/share/cartopy"
+else:
+    CARTOPY_CACHE_DIR = None
 
 
 def venv_cached(session, requirements_file=None):


### PR DESCRIPTION
When a `HOME` environment variable isn't set, `nox --list` currently fails due to trying to cast `None` to a Path. I noticed this when trying to run tests on my Windows PC.

This PR adds a check before casting the env var to a Path. Having `None` as a value should be acceptable - `CARTOPY_CACHE_DIR` is later checked for None values.