### PR TITLE
Prep for 0.17.1 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Getting started
 2. Fork the iris-grib repository, create your new fix/feature branch, and
    start commiting code.
  - The main
-   [Iris development guide](http://scitools.org.uk/iris/docs/latest/developers_guide/gitwash/git_development.html)
+   [Iris development guide](https://scitools-iris.readthedocs.io/en/latest/developers_guide/gitwash/index.html)
    has more detail.
 3. Remember to add appropriate documentation and tests to supplement any new or changed functionality.
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 iris-grib
 =========
 
-|CirrusCI|_ |Coveralls|_
+|CirrusCI|_ |Coveralls|_ |conda-forge|_ |pypi|_ |License|_ |Commits|_ |Contributors|_
 
 GRIB interface for `Iris <https://github.com/SciTools/iris>`_.
 
@@ -24,3 +24,18 @@ terms of its `GNU LGPLv3 license <COPYING.LESSER>`_.
 
 .. |Coveralls| image:: https://coveralls.io/repos/github/SciTools/iris-grib/badge.svg?branch=master
 .. _Coveralls: https://coveralls.io/github/SciTools/iris-grib?branch=master
+
+.. |conda-forge| image:: https://img.shields.io/conda/vn/conda-forge/iris-grib?color=orange&label=conda-forge&logo=conda-forge&logoColor=white
+.. _conda-forge: https://anaconda.org/conda-forge/iris-grib
+
+.. |pypi| image:: https://img.shields.io/pypi/v/iris-grib?color=orange&label=pypi&logo=python&logoColor=white
+.. _pypi: https://pypi.org/project/iris-grib
+
+.. |License| image:: https://img.shields.io/github/license/SciTools/iris-grib?style=plastic
+.. _License: https://github.com/SciTools/iris-grib/blob/master/COPYING
+
+.. |Contributors| image:: https://img.shields.io/github/contributors/SciTools/iris-grib?style=plastic
+.. _Contributors: https://github.com/SciTools/iris-grib/graphs/contributors
+
+.. |Commits| image:: https://img.shields.io/github/commits-since/SciTools/iris-grib/latest.svg?style=plastic
+.. _Commits: https://github.com/SciTools/iris-grib/commits/master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'iris-grib'
-copyright = u'2016, Met Office'
+copyright = u'2021, Met Office'
 author = u'Met Office'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Iris-grib v0.16
+Iris-grib v0.17
 ===============
 
 The library ``iris-grib`` provides functionality for converting between weather and

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -2,6 +2,33 @@ Release Notes
 =============
 
 
+What's new in iris-grib v0.17
+-----------------------------
+
+:Release: 0.17.0
+:Date: 18 May 2021
+
+Features
+^^^^^^^^
+
+* `@m1dr <https://github.com/m1dr>`_ added support for GRIB regulation 92.1.8 
+  for loading GRIB files where the longitude increment is not given.
+  `(PR#261) <https://github.com/SciTools/iris-grib/pull/261>`_
+
+* `@lbdreyer <https://github.com/lbdreyer>`_ added support for loading grid 
+  point and spectral data with CCSDS recommended lossless compression, i.e. 
+  data representation template 42.
+  `(PR#264) <https://github.com/SciTools/iris-grib/pull/264>`_
+
+
+Internal
+^^^^^^^^
+
+* `@jamesp <https://github.com/jamesp>`_ moved CI testing to Cirrus CI.
+  `(PR#250) <https://github.com/SciTools/iris-grib/pull/250>`_
+
+
+
 What's new in iris-grib v0.16
 -----------------------------
 

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -2,6 +2,29 @@ Release Notes
 =============
 
 
+What's new in iris-grib v0.17.1
+-------------------------------
+
+:Release: 0.17.1
+:Date: 3 June 2021
+
+Bugs Fixed
+^^^^^^^^^^
+
+*  `@TomDufall <https://github.com/TomDufall>`_ removed the empty slice
+   handling (originally added in v0.15.1) as this used  
+   iris.util._array_slice_ifempty which was removed in Iris v3.0.2 and is no
+   longer necessary.
+   `(PR#270) <https://github.com/SciTools/iris-grib/pull/270>`_
+
+
+Dependencies
+^^^^^^^^^^^^
+
+* now requires Iris version >= 3.0.2
+
+
+
 What's new in iris-grib v0.17
 -----------------------------
 

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -32,7 +32,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.17.0'
+__version__ = '0.17.1'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -33,7 +33,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.17.dev0'
+__version__ = '0.17.0'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -12,7 +12,6 @@ from collections import namedtuple
 import re
 
 import gribapi
-from iris_grib import _array_slice_ifempty
 import numpy as np
 import numpy.ma as ma
 
@@ -232,35 +231,28 @@ class _DataProxy:
     def __getitem__(self, keys):
         # NB. Currently assumes that the validity of this interpretation
         # is checked before this proxy is created.
+        message = self.recreate_raw()
+        sections = message.sections
+        bitmap_section = sections[6]
+        bitmap = self._bitmap(bitmap_section)
+        data = sections[7]['codedValues']
 
-        # Avoid fetching file data just to return an 'empty' result.
-        # Needed because of how dask.array.from_array behaves since Dask v2.0.
-        result = _array_slice_ifempty(keys, self.shape, self.dtype)
-        if result is None:
-            message = self.recreate_raw()
-            sections = message.sections
-            bitmap_section = sections[6]
-            bitmap = self._bitmap(bitmap_section)
-            data = sections[7]['codedValues']
+        if bitmap is not None:
+            # Note that bitmap and data are both 1D arrays at this point.
+            if np.count_nonzero(bitmap) == data.shape[0]:
+                # Only the non-masked values are included in codedValues.
+                _data = np.empty(shape=bitmap.shape)
+                _data[bitmap.astype(bool)] = data
+                # `ma.masked_array` masks where input = 1, the opposite of
+                # the behaviour specified by the GRIB spec.
+                data = ma.masked_array(_data, mask=np.logical_not(bitmap),
+                                       fill_value=np.nan)
+            else:
+                msg = 'Shapes of data and bitmap do not match.'
+                raise TranslationError(msg)
 
-            if bitmap is not None:
-                # Note that bitmap and data are both 1D arrays at this point.
-                if np.count_nonzero(bitmap) == data.shape[0]:
-                    # Only the non-masked values are included in codedValues.
-                    _data = np.empty(shape=bitmap.shape)
-                    _data[bitmap.astype(bool)] = data
-                    # `ma.masked_array` masks where input = 1, the opposite of
-                    # the behaviour specified by the GRIB spec.
-                    data = ma.masked_array(_data, mask=np.logical_not(bitmap),
-                                           fill_value=np.nan)
-                else:
-                    msg = 'Shapes of data and bitmap do not match.'
-                    raise TranslationError(msg)
-
-            data = data.reshape(self.shape)
-            result = data.__getitem__(keys)
-
-        return result
+        data = data.reshape(self.shape)
+        return data.__getitem__(keys)
 
     def __repr__(self):
         msg = '<{self.__class__.__name__} shape={self.shape} ' \

--- a/iris_grib/tests/unit/message/test__DataProxy.py
+++ b/iris_grib/tests/unit/message/test__DataProxy.py
@@ -43,31 +43,5 @@ class Test__bitmap(tests.IrisGribTest):
             data_proxy._bitmap(section_6)
 
 
-class Test_emptyfetch(tests.IrisGribTest):
-    # See :
-    #   iris.tests.unit.fileformats.pp.test_PPDataProxy.Test__getitem__slicing
-    # In this case, test *only* the no-data-read effect, not the method which
-    # is part of Iris.
-    def test_empty_slice(self):
-        # Check behaviour of the getitem call with an 'empty' slicing.
-        # This is necessary because, since Dask 2.0, the "from_array" function
-        # takes a zero-length slice of its array argument, to capture array
-        # metadata, and in those cases we want to avoid file access.
-        test_dtype = np.dtype(np.float32)
-        mock_datafetch = mock.MagicMock()
-        proxy = _DataProxy(shape=(3, 4),
-                           dtype=np.dtype(np.float32),
-                           recreate_raw=mock_datafetch)
-
-        # Test the special no-data indexing operation.
-        result = proxy[0:0, 0:0]
-
-        # Check the behaviour and results were as expected.
-        self.assertEqual(mock_datafetch.call_count, 0)
-        self.assertIsInstance(result, np.ndarray)
-        self.assertEqual(result.dtype, test_dtype)
-        self.assertEqual(result.shape, (0, 0))
-
-
 if __name__ == '__main__':
     tests.main()

--- a/requirements/ci/py36.yml
+++ b/requirements/ci/py36.yml
@@ -10,7 +10,7 @@ dependencies:
   - setuptools
 
 # Core dependencies.
-  - iris>=3
+  - iris>=3.0.2
   - python-eccodes
 
 # Optional dependencies.

--- a/requirements/ci/py37.yml
+++ b/requirements/ci/py37.yml
@@ -10,7 +10,7 @@ dependencies:
   - setuptools
 
 # Core dependencies.
-  - iris>=3
+  - iris>=3.0.2
   - python-eccodes
 
 # Optional dependencies.

--- a/requirements/ci/py38.yml
+++ b/requirements/ci/py38.yml
@@ -10,7 +10,7 @@ dependencies:
   - setuptools
 
 # Core dependencies.
-  - iris>=3
+  - iris>=3.0.2
   - python-eccodes
 
 # Optional dependencies.

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
 # Core dependencies.
 
-scitools-iris>=3
+scitools-iris>=3.0.2
 eccodes-python


### PR DESCRIPTION
This PR:
* updates the version `0.17.0` -> `0.17.1`
* updates the release notes (see built copy of docs here: https://iris-grib.readthedocs.io/en/docstest_0v17_1/)
* updates the iris requirement from `>=3` to `>=3.0.2`