### PR TITLE
alter calculation of offset

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -145,7 +145,7 @@ class GribWrapper:
         # Store the file pointer and message length from the current
         # grib message before it's changed by calls to the grib-api.
         if deferred:
-            offset = gribapi.grib_get_message_offset(grib_message)
+            offset = eccodes.codes_get_message_offset(grib_message)
 
         # Initialise the key-extension dictionary.
         # NOTE: this attribute *must* exist, or the the __getattr__ overload

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -145,11 +145,6 @@ class GribWrapper:
         # Store the file pointer and message length from the current
         # grib message before it's changed by calls to the grib-api.
         if deferred:
-            # Note that, the grib-api has already read this message and
-            # advanced the file pointer to the end of the message.
-            offset = grib_fh.tell()
-            message_length = eccodes.codes_get_long(
-                grib_message, 'totalLength')
             offset = gribapi.grib_get_message_offset(grib_message)
 
         # Initialise the key-extension dictionary.

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -150,6 +150,7 @@ class GribWrapper:
             offset = grib_fh.tell()
             message_length = eccodes.codes_get_long(
                 grib_message, 'totalLength')
+            offset = gribapi.grib_get_message_offset(grib_message)
 
         # Initialise the key-extension dictionary.
         # NOTE: this attribute *must* exist, or the the __getattr__ overload
@@ -170,11 +171,8 @@ class GribWrapper:
         if deferred:
             # Wrap the reference to the data payload within the data proxy
             # in order to support deferred data loading.
-            # The byte offset requires to be reset back to the first byte
-            # of this message. The file pointer offset is always at the end
-            # of the current message due to the grib-api reading the message.
             proxy = GribDataProxy(shape, np.array([0.]).dtype, grib_fh.name,
-                                  offset - message_length)
+                                  offset)
             self._data = as_lazy_data(proxy)
         else:
             self.data = _message_values(grib_message, shape)

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -59,7 +59,8 @@ class GribMessage:
         file_ref = _OpenFileRef(grib_fh)
 
         while True:
-            grib_id = eccodes.codes_new_from_file(grib_fh)
+            grib_id = eccodes.codes_new_from_file(grib_fh,
+                                                  eccodes.CODES_PRODUCT_GRIB)
             if grib_id is None:
                 break
             offset = eccodes.codes_get_message_offset(grib_id)

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -59,12 +59,10 @@ class GribMessage:
         file_ref = _OpenFileRef(grib_fh)
 
         while True:
-            offset = grib_fh.tell()
-            grib_id = eccodes.codes_new_from_file(
-                grib_fh, eccodes.CODES_PRODUCT_GRIB
-            )
+            grib_id = gribapi.grib_new_from_file(grib_fh)
             if grib_id is None:
                 break
+            offset = gribapi.grib_get_message_offset(grib_id)
             raw_message = _RawGribMessage(grib_id)
             recreate_raw = _MessageLocation(filename, offset)
             yield GribMessage(raw_message, recreate_raw, file_ref=file_ref)

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -59,10 +59,10 @@ class GribMessage:
         file_ref = _OpenFileRef(grib_fh)
 
         while True:
-            grib_id = gribapi.grib_new_from_file(grib_fh)
+            grib_id = eccodes.codes_new_from_file(grib_fh)
             if grib_id is None:
                 break
-            offset = gribapi.grib_get_message_offset(grib_id)
+            offset = eccodes.codes_get_message_offset(grib_id)
             raw_message = _RawGribMessage(grib_id)
             recreate_raw = _MessageLocation(filename, offset)
             yield GribMessage(raw_message, recreate_raw, file_ref=file_ref)

--- a/iris_grib/tests/unit/test_GribWrapper.py
+++ b/iris_grib/tests/unit/test_GribWrapper.py
@@ -21,6 +21,7 @@ from iris.exceptions import TranslationError
 from iris_grib import GribWrapper, _load_generate
 
 
+_offset = 0
 _message_length = 1000
 
 
@@ -50,6 +51,10 @@ def _mock_codes_get_native_type(grib_message, key):
     return result
 
 
+def _mock_codes_get_message_offset(grib_message, key):
+    return _offset
+
+
 class Test_edition(tests.IrisGribTest):
     def setUp(self):
         self.patch('iris_grib.GribWrapper._confirm_in_scope')
@@ -58,7 +63,8 @@ class Test_edition(tests.IrisGribTest):
         self.patch('eccodes.codes_get_string', _mock_codes_get_string)
         self.patch('eccodes.codes_get_native_type',
                    _mock_codes_get_native_type)
-        self.tell = mock.Mock(side_effect=[_message_length])
+        self.patch('eccodes.codes_get_message_offset',
+                   _mock_codes_get_message_offset)
 
     def test_not_edition_1(self):
         def func(grib_message, key):
@@ -71,7 +77,7 @@ class Test_edition(tests.IrisGribTest):
 
     def test_edition_1(self):
         grib_message = 'regular_ll'
-        grib_fh = mock.Mock(tell=self.tell)
+        grib_fh = mock.Mock()
         wrapper = GribWrapper(grib_message, grib_fh)
         self.assertEqual(wrapper.grib_message, grib_message)
 
@@ -99,9 +105,10 @@ class Test_deferred_proxy_args(tests.IrisTest):
         self.patch('eccodes.codes_get_string', _mock_codes_get_string)
         self.patch('eccodes.codes_get_native_type',
                    _mock_codes_get_native_type)
-        tell_tale = np.arange(1, 5) * _message_length
-        self.expected = tell_tale - _message_length
-        self.grib_fh = mock.Mock(tell=mock.Mock(side_effect=tell_tale))
+        self.patch('eccodes.codes_get_message_offset',
+                   _mock_codes_get_message_offset)
+        self.expected = np.atleast_1d(_offset)
+        self.grib_fh = mock.Mock()
         self.dtype = np.float64
         self.path = self.grib_fh.name
         self.lookup = _mock_codes_get_long

--- a/iris_grib/tests/unit/test_GribWrapper.py
+++ b/iris_grib/tests/unit/test_GribWrapper.py
@@ -51,7 +51,7 @@ def _mock_codes_get_native_type(grib_message, key):
     return result
 
 
-def _mock_codes_get_message_offset(grib_message, key):
+def _mock_codes_get_message_offset(grib_message):
     return _offset
 
 


### PR DESCRIPTION
These changes allow the correct calculation of the message offset on both Windows and Linux.

There are three additional test errors introduced as part of these changes (see below - only tested on Linux so far). These are all related to `grib_message` being a string rather than an integer - I'm not particularly familiar with GRIB, so I'm not sure if this is a peculiarity of the tests or that one would expect to encounter a message as a string when loading a file.

```bash
======================================================================
ERROR: test_reduced_proxy_args (unit.test_GribWrapper.Test_deferred_proxy_args)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/net/home/h02/dbentley/defence_applications/tda_source_code/github/iris-grib/iris_grib/tests/unit/test_GribWrapper.py", line 122, in test_reduced_proxy_args
    gw = GribWrapper(grib_message, self.grib_fh)
  File "/net/home/h02/dbentley/defence_applications/tda_source_code/github/iris-grib/iris_grib/__init__.py", line 147, in __init__
    offset = gribapi.grib_get_message_offset(grib_message)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/gribapi/gribapi.py", line 1592, in grib_get_message_offset
    h = get_handle(msgid)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/gribapi/gribapi.py", line 165, in get_handle
    h = ffi.cast("grib_handle*", msgid)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/cffi/api.py", line 300, in cast
    return self._backend.cast(cdecl, source)
TypeError: an integer is required

======================================================================
ERROR: test_regular_proxy_args (unit.test_GribWrapper.Test_deferred_proxy_args)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/net/home/h02/dbentley/defence_applications/tda_source_code/github/iris-grib/iris_grib/tests/unit/test_GribWrapper.py", line 113, in test_regular_proxy_args
    gw = GribWrapper(grib_message, self.grib_fh)
  File "/net/home/h02/dbentley/defence_applications/tda_source_code/github/iris-grib/iris_grib/__init__.py", line 147, in __init__
    offset = gribapi.grib_get_message_offset(grib_message)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/gribapi/gribapi.py", line 1592, in grib_get_message_offset
    h = get_handle(msgid)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/gribapi/gribapi.py", line 165, in get_handle
    h = ffi.cast("grib_handle*", msgid)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/cffi/api.py", line 300, in cast
    return self._backend.cast(cdecl, source)
TypeError: an integer is required

======================================================================
ERROR: test_edition_1 (unit.test_GribWrapper.Test_edition)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/net/home/h02/dbentley/defence_applications/tda_source_code/github/iris-grib/iris_grib/tests/unit/test_GribWrapper.py", line 74, in test_edition_1
    wrapper = GribWrapper(grib_message, grib_fh)
  File "/net/home/h02/dbentley/defence_applications/tda_source_code/github/iris-grib/iris_grib/__init__.py", line 147, in __init__
    offset = gribapi.grib_get_message_offset(grib_message)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/gribapi/gribapi.py", line 1592, in grib_get_message_offset
    h = get_handle(msgid)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/gribapi/gribapi.py", line 165, in get_handle
    h = ffi.cast("grib_handle*", msgid)
  File "/data/users/dbentley/environments/iris-grib-dev/lib/python3.7/site-packages/cffi/api.py", line 300, in cast
    return self._backend.cast(cdecl, source)
TypeError: an integer is required
```