### PR TITLE
Mergeback 0.18.x branch to main

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'iris-grib'
-copyright = u'2021, Met Office'
+copyright = u'2022, Met Office'
 author = u'Met Office'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -297,5 +297,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'iris': ('http://scitools.org.uk/iris/docs/latest/', None),
+    'iris': ('https://scitools-iris.readthedocs.io/en/latest/', None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Iris-grib v0.17
+Iris-grib v0.18
 ===============
 
 The library ``iris-grib`` provides functionality for converting between weather and

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -2,6 +2,38 @@ Release Notes
 =============
 
 
+What's new in iris-grib v0.18.0
+-------------------------------
+
+:Release: 0.18.0
+:Date: 14 March 2022
+
+Bugs Fixed
+^^^^^^^^^^
+* `@lbdreyer <https://github.com/lbdreyer>`_ made various updates to allow 
+  iris-grib to work with the latest versions of 
+  `iris <https://scitools-iris.readthedocs.io/en/stable/>`_,
+  `cf-units <https://cf-units.readthedocs.io/en/latest/>`_,
+  `ecCodes <https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home>`_ and 
+  `cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_, including casting
+  the usage of :meth:`cf_units.Unit.date2num` as float. setting and setting the
+  values of some missing keys using ``gribapi.GRIB_MISSING_LONG``.
+  `(PR#288) <https://github.com/SciTools/iris-grib/pull/288>`_
+
+
+Dependencies
+^^^^^^^^^^^^
+* now requires Python version >= 3.8
+
+
+Internal
+^^^^^^^^
+* `@TomDufall <https://github.com/TomDufall>`_ updated the code so that it was
+  `flake8 <https://flake8.pycqa.org/en/stable/>`_ compliant and enabled flake8 
+  checks to the CI.
+  `(PR#271) <https://github.com/SciTools/iris-grib/pull/271>`_
+
+
 What's new in iris-grib v0.17.1
 -------------------------------
 
@@ -196,6 +228,7 @@ Features
 
 * Updated translations between GRIB parameter code and CF standard_name or
   long_name :
+
       * additional WAFC codes, both to and from CF
       * 'mass_fraction_of_cloud_liquid_water_in_air' and 'mass_fraction_of_cloud_ice_in_air', both to and from CF
       * 'surface_downwelling_longwave_flux_in_air', now translates to GRIBcode(2, 0, 5, 3)  (but not the reverse).

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -31,7 +31,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.18.0'
+__version__ = '0.19.dev0'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']

--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -31,7 +31,7 @@ from ._load_convert import convert as load_convert
 from .message import GribMessage
 
 
-__version__ = '0.18.dev0'
+__version__ = '0.18.0'
 
 __all__ = ['load_cubes', 'save_grib2', 'load_pairs_from_fields',
            'save_pairs_from_cube', 'save_messages']


### PR DESCRIPTION
This PR performs the mergeback of 0.18.x branch back to main after the release of 0.18.0 earlier this week.

I also have updated the version number to now be 0.19.dev0