### PR TITLE
Use reusable workflow for refresh lockfile job

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -1,0 +1,14 @@
+# Updates the environment lock files. See the called workflow in the
+# scitools/reusable_workflows repo for more details.
+name: Refresh Lockfiles
+
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "2 0 * * 7"
+
+jobs:
+  refresh_lockfiles:
+    uses: scitools/reusable_workflows/.github/workflows/refresh-lockfiles.yml@main
+    secrets: inherit

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -6,7 +6,7 @@ name: Refresh Lockfiles
 on:
   workflow_dispatch:
   schedule:
-    - cron: "2 0 * * 7"
+    - cron: "2 0 * * 6"
 
 jobs:
   refresh_lockfiles:


### PR DESCRIPTION
Similar to https://github.com/SciTools/iris/pull/5036

This will use a reusable workflow to run the refresh lockfile job.

~Note I have also added env.yml and lockfiles for Python 3.9 and 3.10~