### PR TITLE
Correct bounded forecast period calculation

### DIFF
--- a/iris_grib/_grib1_load_rules.py
+++ b/iris_grib/_grib1_load_rules.py
@@ -186,11 +186,10 @@ def grib1_convert(grib):
 
     def add_bounded_time_coords(aux_coords_and_dims, grib):
         t_bounds = grib.phenomenon_bounds('hours')
-        period = Unit('hours').convert(t_bounds[1] - t_bounds[0],
-                                       grib._forecastTimeUnit)
+        period = t_bounds[1] - t_bounds[0]
         aux_coords_and_dims.append((
             DimCoord(standard_name='forecast_period',
-                     units=grib._forecastTimeUnit,
+                     units="hours",
                      points=grib._forecastTime + 0.5 * period,
                      bounds=[grib._forecastTime, grib._forecastTime + period]),
             None))

--- a/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
+++ b/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
@@ -58,47 +58,79 @@ class TestBoundedTime(TestField):
                              expected_points=[100],
                              expected_bounds=[[80, 120]])
 
+    def assert_bounded_message_3hours(self, **kwargs):
+        attributes = {'productDefinitionTemplateNumber': 0,
+                      'edition': 1, '_forecastTime': 252,
+                      '_forecastTimeUnit': '3 hours',
+                      'phenomenon_bounds': lambda u: (252, 258),
+                      '_phenomenonDateTime': -1,
+                      'table2Version': 9999,
+                      '_originatingCentre': 'xxx',
+                      }
+        attributes.update(kwargs)
+        message = mock.Mock(**attributes)
+        self._test_for_coord(message, grib1_convert, self.is_forecast_period,
+                             expected_points=[255],
+                             expected_bounds=[[252, 258]])
+        self._test_for_coord(message, grib1_convert, self.is_time,
+                             expected_points=[255],
+                             expected_bounds=[[252, 258]])
+
     def test_time_range_indicator_2(self):
         self.assert_bounded_message(timeRangeIndicator=2)
+        self.assert_bounded_message_3hours(timeRangeIndicator=2)
 
     def test_time_range_indicator_3(self):
         self.assert_bounded_message(timeRangeIndicator=3)
+        self.assert_bounded_message_3hours(timeRangeIndicator=3)
 
     def test_time_range_indicator_4(self):
         self.assert_bounded_message(timeRangeIndicator=4)
+        self.assert_bounded_message_3hours(timeRangeIndicator=4)
 
     def test_time_range_indicator_5(self):
         self.assert_bounded_message(timeRangeIndicator=5)
+        self.assert_bounded_message_3hours(timeRangeIndicator=5)
 
     def test_time_range_indicator_51(self):
         self.assert_bounded_message(timeRangeIndicator=51)
+        self.assert_bounded_message_3hours(timeRangeIndicator=51)
 
     def test_time_range_indicator_113(self):
         self.assert_bounded_message(timeRangeIndicator=113)
+        self.assert_bounded_message_3hours(timeRangeIndicator=113)
 
     def test_time_range_indicator_114(self):
         self.assert_bounded_message(timeRangeIndicator=114)
+        self.assert_bounded_message_3hours(timeRangeIndicator=114)
 
     def test_time_range_indicator_115(self):
         self.assert_bounded_message(timeRangeIndicator=115)
+        self.assert_bounded_message_3hours(timeRangeIndicator=115)
 
     def test_time_range_indicator_116(self):
         self.assert_bounded_message(timeRangeIndicator=116)
+        self.assert_bounded_message_3hours(timeRangeIndicator=116)
 
     def test_time_range_indicator_117(self):
         self.assert_bounded_message(timeRangeIndicator=117)
+        self.assert_bounded_message_3hours(timeRangeIndicator=117)
 
     def test_time_range_indicator_118(self):
         self.assert_bounded_message(timeRangeIndicator=118)
+        self.assert_bounded_message_3hours(timeRangeIndicator=118)
 
     def test_time_range_indicator_123(self):
         self.assert_bounded_message(timeRangeIndicator=123)
+        self.assert_bounded_message_3hours(timeRangeIndicator=123)
 
     def test_time_range_indicator_124(self):
         self.assert_bounded_message(timeRangeIndicator=124)
+        self.assert_bounded_message_3hours(timeRangeIndicator=124)
 
     def test_time_range_indicator_125(self):
         self.assert_bounded_message(timeRangeIndicator=125)
+        self.assert_bounded_message_3hours(timeRangeIndicator=125)
 
 
 class Test_GribLevels(tests.IrisTest):


### PR DESCRIPTION
Addresses #321 by correcting the calculation of the `period` in `forecast_period` coordinates with bounds. Currently the code tries to repeat a conversion of the values for the bounds into hours which results in an incorrect value. In addition the units of the `forecast_period` coordinate are not set to `hours` even though the values are converted to hours.

I suspect the testing I've done could be expanded / improved so I'm particularly keen for feedback which could help improve the coverage.