### PR TITLE
Convert gribapi to eccodes

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -130,6 +130,7 @@ class GribWrapper:
     provides alternative means of working with GRIB message instances.
 
     """
+
     def __init__(self, grib_message, grib_fh=None):
         """Store the grib message and compute our extra keys."""
         self.grib_message = grib_message
@@ -147,7 +148,8 @@ class GribWrapper:
             # Note that, the grib-api has already read this message and
             # advanced the file pointer to the end of the message.
             offset = grib_fh.tell()
-            message_length = eccodes.codes_get_long(grib_message, 'totalLength')
+            message_length = eccodes.codes_get_long(
+                grib_message, 'totalLength')
 
         # Initialise the key-extension dictionary.
         # NOTE: this attribute *must* exist, or the the __getattr__ overload
@@ -162,7 +164,7 @@ class GribWrapper:
         if not self.gridType.startswith('reduced'):
             ni, nj = self.Ni, self.Nj
             j_fast = eccodes.codes_get_long(grib_message,
-                                           'jPointsAreConsecutive')
+                                            'jPointsAreConsecutive')
             shape = (nj, ni) if j_fast == 0 else (ni, nj)
 
         if deferred:
@@ -198,16 +200,19 @@ class GribWrapper:
                          'typeOfSecondFixedSurface'):
                 res = np.int32(eccodes.codes_get_long(self.grib_message, key))
             else:
-                key_type = eccodes.codes_get_native_type(self.grib_message, key)
+                key_type = eccodes.codes_get_native_type(
+                    self.grib_message, key)
                 if key_type == int:
                     res = np.int32(eccodes.codes_get_long(self.grib_message,
-                                                         key))
+                                                          key))
                 elif key_type == float:
                     # Because some computer keys are floats, like
                     # longitudeOfFirstGridPointInDegrees, a float32
                     # is not always enough...
-                    res = np.float64(eccodes.codes_get_double(self.grib_message,
-                                                             key))
+                    res = np.float64(eccodes.codes_get_double(
+                        self.grib_message, key
+                        )
+                    )
                 elif key_type == str:
                     res = eccodes.codes_get_string(self.grib_message, key)
                 else:
@@ -419,7 +424,7 @@ class GribWrapper:
             # (south-to-north) and then put them in the right direction
             # depending on the scan direction
             latitude_points = eccodes.codes_get_double_array(
-                    self.grib_message, 'distinctLatitudes').astype(np.float64)
+                self.grib_message, 'distinctLatitudes').astype(np.float64)
             latitude_points.sort()
             if not self.jScansPositively:
                 # we require latitudes north-to-south

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -204,7 +204,7 @@ def unscale(value, factor):
     return result
 
 
-# Use ECCodes gribapi to recognise missing value
+# Use ECCodes to recognise missing value
 _MDI = None
 
 
@@ -1875,7 +1875,7 @@ def validity_time_coord(frt_coord, fp_coord):
 def time_coords(section, metadata, rt_coord):
     if 'forecastTime' in section.keys():
         forecast_time = section['forecastTime']
-    # The gribapi encodes the forecast time as 'startStep' for pdt 4.4x;
+    # ecCodes encodes the forecast time as 'startStep' for pdt 4.4x;
     # product_definition_template_40 makes use of this function. The
     # following will be removed once the suspected bug is fixed.
     elif 'startStep' in section.keys():

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -94,7 +94,7 @@ def ensure_set_int32_value(grib, key, value):
     """
     try:
         eccodes.codes_set(grib, key, value)
-    except eccodes.GribInternalError:
+    except eccodes.CodesInternalError:
         value = fixup_int32_as_uint32(value)
         eccodes.codes_set(grib, key, value)
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -184,13 +184,13 @@ def shape_of_the_earth(cube, grib):
     # Initially set shape_of_earth keys to missing (255 for byte).
     eccodes.codes_set_long(grib, "scaleFactorOfRadiusOfSphericalEarth", 255)
     eccodes.codes_set_long(grib, "scaledValueOfRadiusOfSphericalEarth",
-                          GRIB_MISSING_LONG)
+                           GRIB_MISSING_LONG)
     eccodes.codes_set_long(grib, "scaleFactorOfEarthMajorAxis", 255)
     eccodes.codes_set_long(grib, "scaledValueOfEarthMajorAxis",
-                          GRIB_MISSING_LONG)
+                           GRIB_MISSING_LONG)
     eccodes.codes_set_long(grib, "scaleFactorOfEarthMinorAxis", 255)
     eccodes.codes_set_long(grib, "scaledValueOfEarthMinorAxis",
-                          GRIB_MISSING_LONG)
+                           GRIB_MISSING_LONG)
 
     if isinstance(cs, GeogCS):
         ellipsoid = cs
@@ -206,7 +206,7 @@ def shape_of_the_earth(cube, grib):
         eccodes.codes_set_long(grib, "shapeOfTheEarth", 1)
         eccodes.codes_set_long(grib, "scaleFactorOfRadiusOfSphericalEarth", 0)
         eccodes.codes_set_long(grib, "scaledValueOfRadiusOfSphericalEarth",
-                              ellipsoid.semi_major_axis)
+                               ellipsoid.semi_major_axis)
         eccodes.codes_set_long(grib, "scaleFactorOfEarthMajorAxis", 0)
         eccodes.codes_set_long(grib, "scaledValueOfEarthMajorAxis", 0)
         eccodes.codes_set_long(grib, "scaleFactorOfEarthMinorAxis", 0)
@@ -216,10 +216,10 @@ def shape_of_the_earth(cube, grib):
         eccodes.codes_set_long(grib, "shapeOfTheEarth", 7)
         eccodes.codes_set_long(grib, "scaleFactorOfEarthMajorAxis", 0)
         eccodes.codes_set_long(grib, "scaledValueOfEarthMajorAxis",
-                              ellipsoid.semi_major_axis)
+                               ellipsoid.semi_major_axis)
         eccodes.codes_set_long(grib, "scaleFactorOfEarthMinorAxis", 0)
         eccodes.codes_set_long(grib, "scaledValueOfEarthMinorAxis",
-                              ellipsoid.semi_minor_axis)
+                               ellipsoid.semi_minor_axis)
 
 
 def grid_dims(x_coord, y_coord, grib, x_str, y_str):
@@ -242,13 +242,13 @@ def latlon_first_last(x_coord, y_coord, grib):
 #                            float(x_coord.points[-1]))
 # WORKAROUND
     eccodes.codes_set_long(grib, "latitudeOfFirstGridPoint",
-                          int(y_coord.points[0]*1000000))
+                           int(y_coord.points[0]*1000000))
     eccodes.codes_set_long(grib, "latitudeOfLastGridPoint",
-                          int(y_coord.points[-1]*1000000))
+                           int(y_coord.points[-1]*1000000))
     eccodes.codes_set_long(grib, "longitudeOfFirstGridPoint",
-                          int((x_coord.points[0] % 360)*1000000))
+                           int((x_coord.points[0] % 360)*1000000))
     eccodes.codes_set_long(grib, "longitudeOfLastGridPoint",
-                          int((x_coord.points[-1] % 360)*1000000))
+                           int((x_coord.points[-1] % 360)*1000000))
 
 
 def dx_dy(x_coord, y_coord, grib):
@@ -259,13 +259,13 @@ def dx_dy(x_coord, y_coord, grib):
     # WMO Manual on Codes regulation 92.1.6
     if x_coord.units == 'degrees':
         eccodes.codes_set(grib, "iDirectionIncrement",
-                         round(1e6 * float(abs(x_step))))
+                          round(1e6 * float(abs(x_step))))
     else:
         raise ValueError('X coordinate must be in degrees, not {}'
                          '.'.format(x_coord.units))
     if y_coord.units == 'degrees':
         eccodes.codes_set(grib, "jDirectionIncrement",
-                         round(1e6 * float(abs(y_step))))
+                          round(1e6 * float(abs(y_step))))
     else:
         raise ValueError('Y coordinate must be in degrees, not {}'
                          '.'.format(y_coord.units))
@@ -273,9 +273,9 @@ def dx_dy(x_coord, y_coord, grib):
 
 def scanning_mode_flags(x_coord, y_coord, grib):
     eccodes.codes_set_long(grib, "iScansPositively",
-                          int(x_coord.points[1] - x_coord.points[0] > 0))
+                           int(x_coord.points[1] - x_coord.points[0] > 0))
     eccodes.codes_set_long(grib, "jScansPositively",
-                          int(y_coord.points[1] - y_coord.points[0] > 0))
+                           int(y_coord.points[1] - y_coord.points[0] > 0))
 
 
 def horizontal_grid_common(cube, grib, xy=False):
@@ -316,9 +316,9 @@ def latlon_points_irregular(cube, grib):
     lon_values = x_coord.points / _DEFAULT_DEGREES_UNITS
     lat_values = y_coord.points / _DEFAULT_DEGREES_UNITS
     eccodes.codes_set_array(grib, 'longitudes',
-                           np.array(np.round(lon_values), dtype=np.int64))
+                            np.array(np.round(lon_values), dtype=np.int64))
     eccodes.codes_set_array(grib, 'latitudes',
-                           np.array(np.round(lat_values), dtype=np.int64))
+                            np.array(np.round(lat_values), dtype=np.int64))
 
 
 def rotated_pole(cube, grib):
@@ -488,24 +488,24 @@ def grid_definition_template_10(cube, grib):
     last_x = last_x % 360
 
     eccodes.codes_set(grib, "latitudeOfFirstGridPoint",
-                     int(np.round(first_y / _DEFAULT_DEGREES_UNITS)))
+                      int(np.round(first_y / _DEFAULT_DEGREES_UNITS)))
     eccodes.codes_set(grib, "longitudeOfFirstGridPoint",
-                     int(np.round(first_x / _DEFAULT_DEGREES_UNITS)))
+                      int(np.round(first_x / _DEFAULT_DEGREES_UNITS)))
     eccodes.codes_set(grib, "latitudeOfLastGridPoint",
-                     int(np.round(last_y / _DEFAULT_DEGREES_UNITS)))
+                      int(np.round(last_y / _DEFAULT_DEGREES_UNITS)))
     eccodes.codes_set(grib, "longitudeOfLastGridPoint",
-                     int(np.round(last_x / _DEFAULT_DEGREES_UNITS)))
+                      int(np.round(last_x / _DEFAULT_DEGREES_UNITS)))
 
     # Check and raise a more intelligible error, if the Iris version is too old
     # to support the Mercator 'standard_parallel' property.
     confirm_extended_mercator_supported()
     # Encode the latitude at which the projection intersects the Earth.
     eccodes.codes_set(grib, 'LaD',
-                     cs.standard_parallel / _DEFAULT_DEGREES_UNITS)
+                      cs.standard_parallel / _DEFAULT_DEGREES_UNITS)
 
     # Encode resolution and component flags
     eccodes.codes_set(grib, 'resolutionAndComponentFlags',
-                     0x1 << _RESOLUTION_AND_COMPONENTS_GRID_WINDS_BIT)
+                      0x1 << _RESOLUTION_AND_COMPONENTS_GRID_WINDS_BIT)
 
 
 def grid_definition_template_12(cube, grib):
@@ -553,10 +553,14 @@ def grid_definition_template_12(cube, grib):
     ensure_set_int32_value(grib, 'X2', int(x_cm[-1]))
 
     # Lat and lon of reference point are measured in millionths of a degree.
-    eccodes.codes_set(grib, "latitudeOfReferencePoint",
-                     cs.latitude_of_projection_origin / _DEFAULT_DEGREES_UNITS)
-    eccodes.codes_set(grib, "longitudeOfReferencePoint",
-                     cs.longitude_of_central_meridian / _DEFAULT_DEGREES_UNITS)
+    eccodes.codes_set(
+        grib, "latitudeOfReferencePoint",
+        cs.latitude_of_projection_origin / _DEFAULT_DEGREES_UNITS
+    )
+    eccodes.codes_set(
+        grib, "longitudeOfReferencePoint",
+        cs.longitude_of_central_meridian / _DEFAULT_DEGREES_UNITS
+    )
 
     # Convert a value in metres into the closest integer number of
     # centimetres.
@@ -572,7 +576,7 @@ def grid_definition_template_12(cube, grib):
     # See https://software.ecmwf.int/issues/browse/SUP-1100
     value = cs.scale_factor_at_central_meridian
     key_type = eccodes.codes_get_native_type(grib,
-                                            "scaleFactorAtReferencePoint")
+                                             "scaleFactorAtReferencePoint")
     if key_type is not float:
         value = fixup_float32_as_int32(value)
     eccodes.codes_set(grib, "scaleFactorAtReferencePoint", value)
@@ -625,16 +629,16 @@ def grid_definition_template_30(cube, grib):
     central_lon = cs.central_lon % 360
 
     eccodes.codes_set(grib, "latitudeOfFirstGridPoint",
-                     int(np.round(first_y / _DEFAULT_DEGREES_UNITS)))
+                      int(np.round(first_y / _DEFAULT_DEGREES_UNITS)))
     eccodes.codes_set(grib, "longitudeOfFirstGridPoint",
-                     int(np.round(first_x / _DEFAULT_DEGREES_UNITS)))
+                      int(np.round(first_x / _DEFAULT_DEGREES_UNITS)))
     eccodes.codes_set(grib, "LaD", cs.central_lat / _DEFAULT_DEGREES_UNITS)
     eccodes.codes_set(grib, "LoV", central_lon / _DEFAULT_DEGREES_UNITS)
     latin1, latin2 = cs.secant_latitudes
     eccodes.codes_set(grib, "Latin1", latin1 / _DEFAULT_DEGREES_UNITS)
     eccodes.codes_set(grib, "Latin2", latin2 / _DEFAULT_DEGREES_UNITS)
     eccodes.codes_set(grib, 'resolutionAndComponentFlags',
-                     0x1 << _RESOLUTION_AND_COMPONENTS_GRID_WINDS_BIT)
+                      0x1 << _RESOLUTION_AND_COMPONENTS_GRID_WINDS_BIT)
 
     # Which pole are the parallels closest to? That is the direction
     # that the cone converges.
@@ -930,7 +934,7 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
         eccodes.codes_set(grib, "typeOfSecondFixedSurface", 255)
         eccodes.codes_set(grib, "scaleFactorOfSecondFixedSurface", 255)
         eccodes.codes_set(grib, "scaledValueOfSecondFixedSurface",
-                         GRIB_MISSING_LONG)
+                          GRIB_MISSING_LONG)
     elif not v_coord.has_bounds():
         # No second surface
         output_v = v_coord.units.convert(v_coord.points[0], output_unit)
@@ -944,7 +948,7 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
         eccodes.codes_set(grib, "typeOfSecondFixedSurface", 255)
         eccodes.codes_set(grib, "scaleFactorOfSecondFixedSurface", 255)
         eccodes.codes_set(grib, "scaledValueOfSecondFixedSurface",
-                         GRIB_MISSING_LONG)
+                          GRIB_MISSING_LONG)
     else:
         # bounded : set lower+upper surfaces
         output_v = v_coord.units.convert(v_coord.bounds[0], output_unit)
@@ -955,9 +959,9 @@ def set_fixed_surfaces(cube, grib, full3d_cube=None):
         eccodes.codes_set(grib, "scaleFactorOfFirstFixedSurface", 0)
         eccodes.codes_set(grib, "scaleFactorOfSecondFixedSurface", 0)
         eccodes.codes_set(grib, "scaledValueOfFirstFixedSurface",
-                         int(round(output_v[0])))
+                          int(round(output_v[0])))
         eccodes.codes_set(grib, "scaledValueOfSecondFixedSurface",
-                         int(round(output_v[1])))
+                          int(round(output_v[1])))
 
     if hybrid_factory is not None:
         # Need to record ALL the level coefficents in a 'PV' vector.
@@ -1017,7 +1021,7 @@ def set_time_range(time_coord, grib):
 
     # Set type to hours and convert period to this unit.
     eccodes.codes_set(grib, "indicatorOfUnitForTimeRange",
-                     _TIME_RANGE_UNITS['hours'])
+                      _TIME_RANGE_UNITS['hours'])
     hours_since_units = cf_units.Unit('hours since epoch',
                                       calendar=time_coord.units.calendar)
     start_hours, end_hours = time_coord.units.convert(time_coord.bounds[0],
@@ -1177,7 +1181,7 @@ def set_ensemble(cube, grib):
         raise ValueError("A cube 'realization' coordinate with one "
                          "point is required, but not present")
     eccodes.codes_set(grib, "perturbationNumber",
-                     int(cube.coord('realization').points[0]))
+                      int(cube.coord('realization').points[0]))
     # no encoding at present in iris-grib, set to missing
     eccodes.codes_set(grib, "numberOfForecastsInEnsemble", 255)
     eccodes.codes_set(grib, "typeOfEnsembleForecast", 255)
@@ -1259,7 +1263,7 @@ def product_definition_template_10(cube, grib, full3d_cube=None):
         raise ValueError("A cube 'percentile_over_time' coordinate with one "
                          "point is required, but not present.")
     eccodes.codes_set(grib, "percentileValue",
-                     int(cube.coord('percentile_over_time').points[0]))
+                      int(cube.coord('percentile_over_time').points[0]))
     _product_definition_template_8_10_and_11(cube, grib)
 
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -1502,7 +1502,7 @@ def data_section(cube, grib):
     eccodes.codes_set_double_array(grib, "values", data.flatten())
 
     # todo: check packing accuracy?
-#    print("packingError", eccodes.getb_get_double(grib, "packingError"))
+#    print("packingError", eccodes.get_get_double(grib, "packingError"))
 
 
 ###############################################################################

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -76,7 +76,7 @@ class GribMessage:
         them directly.
 
         """
-        # A RawGribMessage giving gribapi access to the original grib message.
+        # A RawGribMessage giving ecCodes access to the original grib message.
         self._raw_message = raw_message
         # A _MessageLocation which dask uses to read the message data array,
         # by which time this message may be dead and the original grib file
@@ -309,7 +309,7 @@ class _RawGribMessage:
 
     def __del__(self):
         """
-        Release the gribapi reference to the message at end of object's life.
+        Release the ecCodes reference to the message at end of object's life.
 
         """
         eccodes.codes_release(self._message_id)
@@ -443,7 +443,7 @@ class Section:
             res = eccodes.codes_get_array(self._message_id, key)
         elif key == 'bitmap':
             # The bitmap is stored as contiguous boolean bits, one bit for each
-            # data point. GRIBAPI returns these as strings, so it must be
+            # data point. ecCodes returns these as strings, so it must be
             # type-cast to return an array of ints (0, 1).
             res = eccodes.codes_get_array(self._message_id, key, int)
         elif key in ('typeOfFirstFixedSurface', 'typeOfSecondFixedSurface'):

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -11,7 +11,7 @@ Defines a lightweight wrapper class to wrap a single GRIB message.
 from collections import namedtuple
 import re
 
-import gribapi
+import eccodes
 import numpy as np
 import numpy.ma as ma
 
@@ -60,7 +60,9 @@ class GribMessage:
 
         while True:
             offset = grib_fh.tell()
-            grib_id = gribapi.grib_new_from_file(grib_fh)
+            grib_id = eccodes.codes_new_from_file(
+                grib_fh, eccodes.CODES_PRODUCT_GRIB
+            )
             if grib_id is None:
                 break
             raw_message = _RawGribMessage(grib_id)
@@ -282,7 +284,9 @@ class _RawGribMessage:
     def from_file_offset(filename, offset):
         with open(filename, 'rb') as f:
             f.seek(offset)
-            message_id = gribapi.grib_new_from_file(f)
+            message_id = eccodes.codes_new_from_file(
+                f, eccodes.CODES_PRODUCT_GRIB
+            )
             if message_id is None:
                 fmt = 'Invalid GRIB message: {} @ {}'
                 raise RuntimeError(fmt.format(filename, offset))
@@ -308,7 +312,7 @@ class _RawGribMessage:
         Release the gribapi reference to the message at end of object's life.
 
         """
-        gribapi.grib_release(self._message_id)
+        eccodes.codes_release(self._message_id)
 
     @property
     def sections(self):
@@ -330,11 +334,11 @@ class _RawGribMessage:
     def _get_message_keys(self):
         """Creates a generator of all the keys in the message."""
 
-        keys_itr = gribapi.grib_keys_iterator_new(self._message_id)
-        gribapi.grib_skip_computed(keys_itr)
-        while gribapi.grib_keys_iterator_next(keys_itr):
-            yield gribapi.grib_keys_iterator_get_name(keys_itr)
-        gribapi.grib_keys_iterator_delete(keys_itr)
+        keys_itr = eccodes.codes_keys_iterator_new(self._message_id)
+        eccodes.codes_skip_computed(keys_itr)
+        while eccodes.codes_keys_iterator_next(keys_itr):
+            yield eccodes.codes_keys_iterator_get_name(keys_itr)
+        eccodes.codes_keys_iterator_delete(keys_itr)
 
     def _get_message_sections(self):
         """
@@ -436,12 +440,12 @@ class Section:
                        'scaledValueOfCentralWaveNumber',
                        'longitudes', 'latitudes')
         if key in vector_keys:
-            res = gribapi.grib_get_array(self._message_id, key)
+            res = eccodes.codes_get_array(self._message_id, key)
         elif key == 'bitmap':
             # The bitmap is stored as contiguous boolean bits, one bit for each
             # data point. GRIBAPI returns these as strings, so it must be
             # type-cast to return an array of ints (0, 1).
-            res = gribapi.grib_get_array(self._message_id, key, int)
+            res = eccodes.codes_get_array(self._message_id, key, int)
         elif key in ('typeOfFirstFixedSurface', 'typeOfSecondFixedSurface'):
             # By default these values are returned as unhelpful strings but
             # we can use int representation to compare against instead.
@@ -466,7 +470,7 @@ class Section:
         """
         vector_keys = ('longitudes', 'latitudes', 'distinctLatitudes')
         if key in vector_keys:
-            res = gribapi.grib_get_array(self._message_id, key)
+            res = eccodes.codes_get_array(self._message_id, key)
         else:
             res = self._get_value_or_missing(key)
         return res
@@ -481,11 +485,11 @@ class Section:
         Implementation of Regulations 92.1.4 and 92.1.5 via ECCodes.
 
         """
-        if gribapi.grib_is_missing(self._message_id, key):
+        if eccodes.codes_is_missing(self._message_id, key):
             result = None
         else:
             if use_int:
-                result = gribapi.grib_get(self._message_id, key, int)
+                result = eccodes.codes_get(self._message_id, key, int)
             else:
-                result = gribapi.grib_get(self._message_id, key)
+                result = eccodes.codes_get(self._message_id, key)
         return result

--- a/iris_grib/tests/integration/save_rules/test_grib_save.py
+++ b/iris_grib/tests/integration/save_rules/test_grib_save.py
@@ -26,7 +26,7 @@ import iris.coords
 import iris.exceptions
 import iris.util
 
-import gribapi
+import eccodes
 from iris_grib._load_convert import _MDI as MDI
 
 
@@ -211,15 +211,17 @@ class TestCubeSave(tests.IrisGribTest):
         with self.temp_filename(".grib2") as testfile:
             iris.save(cube, testfile)
             with open(testfile, "rb") as saved_file:
-                g = gribapi.grib_new_from_file(saved_file)
+                g = eccodes.codes_new_from_file(
+                    saved_file, eccodes.CODES_PRODUCT_GRIB
+                )
                 self.assertEqual(
-                    gribapi.grib_get_double(
+                    eccodes.codes_get_double(
                         g, "scaledValueOfFirstFixedSurface"
                     ),
                     0.0,
                 )
                 self.assertEqual(
-                    gribapi.grib_get_double(
+                    eccodes.codes_get_double(
                         g, "scaledValueOfSecondFixedSurface"
                     ),
                     2147483647.0,

--- a/iris_grib/tests/unit/__init__.py
+++ b/iris_grib/tests/unit/__init__.py
@@ -27,7 +27,7 @@ def _make_test_message(sections):
 
 def _mock_eccodes_fetch(message, key):
     """
-    Fake the gribapi key-fetch.
+    Fake the ecCodes key-fetch.
 
     Fetch key-value from the fake message (dictionary).
     If the key is not present, raise the diagnostic exception.
@@ -41,7 +41,7 @@ def _mock_eccodes_fetch(message, key):
 
 def _mock_eccodes__codes_is_missing(grib_message, keyname):
     """
-    Fake the gribapi key-existence enquiry.
+    Fake the ecCodes key-existence enquiry.
 
     Return whether the key exists in the fake message (dictionary).
 
@@ -51,7 +51,7 @@ def _mock_eccodes__codes_is_missing(grib_message, keyname):
 
 def _mock_eccodes__codes_get_native_type(grib_message, keyname):
     """
-    Fake the gribapi type-discovery operation.
+    Fake the ecCodes type-discovery operation.
 
     Return type of key-value in the fake message (dictionary).
     If the key is not present, raise the diagnostic exception.

--- a/iris_grib/tests/unit/__init__.py
+++ b/iris_grib/tests/unit/__init__.py
@@ -9,7 +9,7 @@
 # before importing anything else.
 import iris_grib.tests as tests
 
-import gribapi
+import eccodes
 import numpy as np
 from unittest import mock
 
@@ -25,7 +25,7 @@ def _make_test_message(sections):
     return GribMessage(raw_message, recreate_raw)
 
 
-def _mock_gribapi_fetch(message, key):
+def _mock_eccodes_fetch(message, key):
     """
     Fake the gribapi key-fetch.
 
@@ -36,10 +36,10 @@ def _mock_gribapi_fetch(message, key):
     if key in message:
         return message[key]
     else:
-        raise _mock_gribapi.GribInternalError
+        raise _mock_eccodes.GribInternalError
 
 
-def _mock_gribapi__grib_is_missing(grib_message, keyname):
+def _mock_eccodes__codes_is_missing(grib_message, keyname):
     """
     Fake the gribapi key-existence enquiry.
 
@@ -49,7 +49,7 @@ def _mock_gribapi__grib_is_missing(grib_message, keyname):
     return (keyname not in grib_message)
 
 
-def _mock_gribapi__grib_get_native_type(grib_message, keyname):
+def _mock_eccodes__codes_get_native_type(grib_message, keyname):
     """
     Fake the gribapi type-discovery operation.
 
@@ -59,22 +59,22 @@ def _mock_gribapi__grib_get_native_type(grib_message, keyname):
     """
     if keyname in grib_message:
         return type(grib_message[keyname])
-    raise _mock_gribapi.GribInternalError(keyname)
+    raise _mock_eccodes.GribInternalError(keyname)
 
 
-# Construct a mock object to mimic the gribapi for GribWrapper testing.
-_mock_gribapi = mock.Mock(spec=gribapi)
-_mock_gribapi.GribInternalError = Exception
+# Construct a mock object to mimic the eccodes for GribWrapper testing.
+_mock_eccodes = mock.Mock(spec=eccodes)
+_mock_eccodes.GribInternalError = Exception
 
-_mock_gribapi.grib_get_long = mock.Mock(side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_get_string = mock.Mock(side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_get_double = mock.Mock(side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_get_double_array = mock.Mock(
-    side_effect=_mock_gribapi_fetch)
-_mock_gribapi.grib_is_missing = mock.Mock(
-    side_effect=_mock_gribapi__grib_is_missing)
-_mock_gribapi.grib_get_native_type = mock.Mock(
-    side_effect=_mock_gribapi__grib_get_native_type)
+_mock_eccodes.codes_get_long = mock.Mock(side_effect=_mock_eccodes_fetch)
+_mock_eccodes.codes_get_string = mock.Mock(side_effect=_mock_eccodes_fetch)
+_mock_eccodes.codes_get_double = mock.Mock(side_effect=_mock_eccodes_fetch)
+_mock_eccodes.codes_get_double_array = mock.Mock(
+    side_effect=_mock_eccodes_fetch)
+_mock_eccodes.codes_is_missing = mock.Mock(
+    side_effect=_mock_eccodes__codes_is_missing)
+_mock_eccodes.codes_get_native_type = mock.Mock(
+    side_effect=_mock_eccodes__codes_get_native_type)
 
 
 class FakeGribMessage(dict):
@@ -212,7 +212,7 @@ class TestGribSimple(tests.IrisGribTest):
     def cube_from_message(self, grib):
         # Parameter translation now uses the GribWrapper, so we must convert
         # the Mock-based fake message to a FakeGribMessage.
-        with mock.patch('iris_grib.gribapi', _mock_gribapi):
+        with mock.patch('iris_grib.eccodes', _mock_eccodes):
             grib_message = FakeGribMessage(**grib.__dict__)
             wrapped_msg = iris_grib.GribWrapper(grib_message)
             cube, _, _ = iris.fileformats.rules._make_cube(

--- a/iris_grib/tests/unit/__init__.py
+++ b/iris_grib/tests/unit/__init__.py
@@ -36,7 +36,7 @@ def _mock_eccodes_fetch(message, key):
     if key in message:
         return message[key]
     else:
-        raise _mock_eccodes.GribInternalError
+        raise _mock_eccodes.CodesInternalError
 
 
 def _mock_eccodes__codes_is_missing(grib_message, keyname):
@@ -59,12 +59,12 @@ def _mock_eccodes__codes_get_native_type(grib_message, keyname):
     """
     if keyname in grib_message:
         return type(grib_message[keyname])
-    raise _mock_eccodes.GribInternalError(keyname)
+    raise _mock_eccodes.CodesInternalError(keyname)
 
 
 # Construct a mock object to mimic the eccodes for GribWrapper testing.
 _mock_eccodes = mock.Mock(spec=eccodes)
-_mock_eccodes.GribInternalError = Exception
+_mock_eccodes.CodesInternalError = Exception
 
 _mock_eccodes.codes_get_long = mock.Mock(side_effect=_mock_eccodes_fetch)
 _mock_eccodes.codes_get_string = mock.Mock(side_effect=_mock_eccodes_fetch)

--- a/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
+++ b/iris_grib/tests/unit/grib1_load_rules/test_grib1_convert.py
@@ -9,7 +9,7 @@
 # importing anything else
 import iris_grib.tests as tests
 
-import gribapi
+import eccodes
 from unittest import mock
 
 from iris.aux_factory import HybridPressureFactory
@@ -135,7 +135,7 @@ class TestBoundedTime(TestField):
 
 class Test_GribLevels(tests.IrisTest):
     def test_grib1_hybrid_height(self):
-        gm = gribapi.grib_new_from_samples('regular_gg_ml_grib1')
+        gm = eccodes.codes_grib_new_from_samples('regular_gg_ml_grib1')
         gw = GribWrapper(gm)
         results = grib1_convert(gw)
 

--- a/iris_grib/tests/unit/grib1_load_rules/test_grib1_load_translations.py
+++ b/iris_grib/tests/unit/grib1_load_rules/test_grib1_load_translations.py
@@ -30,7 +30,7 @@ import iris_grib
 
 def _mock_eccodes_fetch(message, key):
     """
-    Fake the gribapi key-fetch.
+    Fake the ecCodes key-fetch.
 
     Fetch key-value from the fake message (dictionary).
     If the key is not present, raise the diagnostic exception.
@@ -44,7 +44,7 @@ def _mock_eccodes_fetch(message, key):
 
 def _mock_eccodes__codes_is_missing(grib_message, keyname):
     """
-    Fake the gribapi key-existence enquiry.
+    Fake the ecCodes key-existence enquiry.
 
     Return whether the key exists in the fake message (dictionary).
 
@@ -54,7 +54,7 @@ def _mock_eccodes__codes_is_missing(grib_message, keyname):
 
 def _mock_eccodes__codes_get_native_type(grib_message, keyname):
     """
-    Fake the gribapi type-discovery operation.
+    Fake the ecCodes type-discovery operation.
 
     Return type of key-value in the fake message (dictionary).
     If the key is not present, raise the diagnostic exception.
@@ -65,7 +65,7 @@ def _mock_eccodes__codes_get_native_type(grib_message, keyname):
     raise _mock_eccodes.CodesInternalError(keyname)
 
 
-# Construct a mock object to mimic the gribapi for GribWrapper testing.
+# Construct a mock object to mimic the ecCodes for GribWrapper testing.
 _mock_eccodes = mock.Mock(spec=eccodes)
 _mock_eccodes.CodesInternalError = Exception
 

--- a/iris_grib/tests/unit/message/test_Section.py
+++ b/iris_grib/tests/unit/message/test_Section.py
@@ -12,7 +12,7 @@ Unit tests for `iris_grib.message.Section`.
 # importing anything else.
 import iris_grib.tests as tests
 
-import gribapi
+import eccodes
 import numpy as np
 
 from iris_grib.message import Section
@@ -23,7 +23,9 @@ class Test___getitem__(tests.IrisGribTest):
     def setUp(self):
         filename = tests.get_data_path(('GRIB', 'uk_t', 'uk_t.grib2'))
         with open(filename, 'rb') as grib_fh:
-            self.grib_id = gribapi.grib_new_from_file(grib_fh)
+            self.grib_id = eccodes.codes_new_from_file(
+                grib_fh, eccodes.CODES_PRODUCT_GRIB
+            )
 
     def test_scalar(self):
         section = Section(self.grib_id, None, ['Ni'])
@@ -56,7 +58,9 @@ class Test__getitem___pdt_31(tests.IrisGribTest):
     def setUp(self):
         filename = tests.get_data_path(('GRIB', 'umukv', 'ukv_chan9.grib2'))
         with open(filename, 'rb') as grib_fh:
-            self.grib_id = gribapi.grib_new_from_file(grib_fh)
+            self.grib_id = eccodes.codes_new_from_file(
+                grib_fh, eccodes.CODES_PRODUCT_GRIB
+            )
         self.keys = ['satelliteSeries', 'satelliteNumber', 'instrumentType',
                      'scaleFactorOfCentralWaveNumber',
                      'scaledValueOfCentralWaveNumber']
@@ -74,7 +78,9 @@ class Test_get_computed_key(tests.IrisGribTest):
     def test_gdt40_computed(self):
         fname = tests.get_data_path(('GRIB', 'gaussian', 'regular_gg.grib2'))
         with open(fname, 'rb') as grib_fh:
-            self.grib_id = gribapi.grib_new_from_file(grib_fh)
+            self.grib_id = eccodes.codes_new_from_file(
+                grib_fh, eccodes.CODES_PRODUCT_GRIB
+            )
             section = Section(self.grib_id, None, [])
         latitudes = section.get_computed_key('latitudes')
         self.assertTrue(88.55 < latitudes[0] < 88.59)

--- a/iris_grib/tests/unit/message/test__RawGribMessage.py
+++ b/iris_grib/tests/unit/message/test__RawGribMessage.py
@@ -12,7 +12,7 @@ Unit tests for the `iris_grib.message._RawGribMessage` class.
 # importing anything else.
 import iris_grib.tests as tests
 
-import gribapi
+import eccodes
 
 from iris_grib.message import _RawGribMessage
 
@@ -22,7 +22,9 @@ class Test(tests.IrisGribTest):
     def setUp(self):
         filename = tests.get_data_path(('GRIB', 'uk_t', 'uk_t.grib2'))
         with open(filename, 'rb') as grib_fh:
-            grib_id = gribapi.grib_new_from_file(grib_fh)
+            grib_id = eccodes.codes_new_from_file(
+                grib_fh, eccodes.CODES_PRODUCT_GRIB
+            )
             self.message = _RawGribMessage(grib_id)
 
     def test_sections__set(self):

--- a/iris_grib/tests/unit/message/test__RawGribMessage.py
+++ b/iris_grib/tests/unit/message/test__RawGribMessage.py
@@ -43,7 +43,7 @@ class Test(tests.IrisGribTest):
 
     def test_sections__numberOfSection_value(self):
         # The key `numberOfSection` is repeated in every section meaning that
-        # if requested using gribapi it always defaults to its last value (7).
+        # if requested using ecCodes it always defaults to its last value (7).
         # This tests that the `_RawGribMessage._get_message_sections`
         # override is functioning.
         section_number = 4

--- a/iris_grib/tests/unit/save_rules/__init__.py
+++ b/iris_grib/tests/unit/save_rules/__init__.py
@@ -23,10 +23,10 @@ class GdtTestMixin:
     TARGET_MODULE = 'iris_grib._save_rules'
 
     def setUp(self):
-        # Patch the gribapi of the tested module.
+        # Patch the ecCodes of the tested module.
         self.mock_eccodes = self.patch(self.TARGET_MODULE + '.eccodes')
 
-        # Fix the mock gribapi to record key assignments.
+        # Fix the mock ecCodes to record key assignments.
         def codes_set_trap(grib, name, value):
             # Record a key setting on the mock passed as the 'grib message id'.
             grib.keys[name] = value

--- a/iris_grib/tests/unit/save_rules/__init__.py
+++ b/iris_grib/tests/unit/save_rules/__init__.py
@@ -24,19 +24,19 @@ class GdtTestMixin:
 
     def setUp(self):
         # Patch the gribapi of the tested module.
-        self.mock_gribapi = self.patch(self.TARGET_MODULE + '.gribapi')
+        self.mock_eccodes = self.patch(self.TARGET_MODULE + '.eccodes')
 
         # Fix the mock gribapi to record key assignments.
-        def grib_set_trap(grib, name, value):
+        def codes_set_trap(grib, name, value):
             # Record a key setting on the mock passed as the 'grib message id'.
             grib.keys[name] = value
 
-        self.mock_gribapi.grib_set = grib_set_trap
-        self.mock_gribapi.grib_set_long = grib_set_trap
-        self.mock_gribapi.grib_set_float = grib_set_trap
-        self.mock_gribapi.grib_set_double = grib_set_trap
-        self.mock_gribapi.grib_set_long_array = grib_set_trap
-        self.mock_gribapi.grib_set_array = grib_set_trap
+        self.mock_eccodes.codes_set = codes_set_trap
+        self.mock_eccodes.codes_set_long = codes_set_trap
+        self.mock_eccodes.codes_set_float = codes_set_trap
+        self.mock_eccodes.codes_set_double = codes_set_trap
+        self.mock_eccodes.codes_set_long_array = codes_set_trap
+        self.mock_eccodes.codes_set_array = codes_set_trap
 
         # Create a mock 'grib message id', with a 'keys' dict for settings.
         self.mock_grib = mock.Mock(keys={})

--- a/iris_grib/tests/unit/save_rules/test__product_definition_template_8_10_and_11.py
+++ b/iris_grib/tests/unit/save_rules/test__product_definition_template_8_10_and_11.py
@@ -16,7 +16,7 @@ import iris_grib.tests as tests
 from unittest import mock
 
 from cf_units import Unit
-import gribapi
+import eccodes
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock
@@ -33,7 +33,7 @@ class TestTypeOfStatisticalProcessing(tests.IrisGribTest):
                          units=Unit('days since epoch', calendar='standard'))
         self.cube.add_aux_coord(coord)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_sum(self, mock_set):
         cube = self.cube
         cell_method = CellMethod(method='sum', coords=['time'])
@@ -43,7 +43,7 @@ class TestTypeOfStatisticalProcessing(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "typeOfStatisticalProcessing", 1)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_unrecognised(self, mock_set):
         cube = self.cube
         cell_method = CellMethod(method='95th percentile', coords=['time'])
@@ -53,7 +53,7 @@ class TestTypeOfStatisticalProcessing(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "typeOfStatisticalProcessing", 255)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_multiple_cell_method_coords(self, mock_set):
         cube = self.cube
         cell_method = CellMethod(method='sum',
@@ -63,7 +63,7 @@ class TestTypeOfStatisticalProcessing(tests.IrisGribTest):
                                     'Cannot handle multiple coordinate name'):
             _product_definition_template_8_10_and_11(cube, mock.sentinel.grib)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_cell_method_coord_name_fail(self, mock_set):
         cube = self.cube
         cell_method = CellMethod(method='mean', coords=['season'])
@@ -80,7 +80,7 @@ class TestTimeCoordPrerequisites(tests.IrisGribTest):
         # Rename cube to avoid warning about unknown discipline/parameter.
         self.cube.rename('air_temperature')
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_multiple_points(self, mock_set):
         # Add time coord with multiple points.
         coord = DimCoord([23, 24, 25], 'time',
@@ -92,7 +92,7 @@ class TestTimeCoordPrerequisites(tests.IrisGribTest):
             _product_definition_template_8_10_and_11(self.cube,
                                                      mock.sentinel.grib)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_no_bounds(self, mock_set):
         # Add time coord with no bounds.
         coord = DimCoord(23, 'time',
@@ -104,7 +104,7 @@ class TestTimeCoordPrerequisites(tests.IrisGribTest):
             _product_definition_template_8_10_and_11(self.cube,
                                                      mock.sentinel.grib)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_more_than_two_bounds(self, mock_set):
         # Add time coord with more than two bounds.
         coord = DimCoord(23, 'time', bounds=[21, 22, 23],
@@ -125,7 +125,7 @@ class TestEndOfOverallTimeInterval(tests.IrisGribTest):
         cell_method = CellMethod(method='sum', coords=['time'])
         self.cube.add_cell_method(cell_method)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_default_calendar(self, mock_set):
         cube = self.cube
         # End bound is 1972-04-26 10:27:07.
@@ -149,7 +149,7 @@ class TestEndOfOverallTimeInterval(tests.IrisGribTest):
         mock_set.assert_any_call(
             grib, "secondOfEndOfOverallTimeInterval", 7)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_360_day_calendar(self, mock_set):
         cube = self.cube
         # End bound is 1972-05-07 10:27:07
@@ -175,7 +175,7 @@ class TestEndOfOverallTimeInterval(tests.IrisGribTest):
 
 
 class TestNumberOfTimeRange(tests.IrisGribTest):
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_other_cell_methods(self, mock_set):
         cube = stock.lat_lon_cube()
         # Rename cube to avoid warning about unknown discipline/parameter.

--- a/iris_grib/tests/unit/save_rules/test_data_section.py
+++ b/iris_grib/tests/unit/save_rules/test_data_section.py
@@ -14,42 +14,42 @@ import iris_grib.tests as tests
 
 from unittest import mock
 
-import gribapi
+import eccodes
 import iris.cube
 import numpy as np
 
 from iris_grib._save_rules import data_section
 
 
-GRIB_API = 'iris_grib._save_rules.gribapi'
+GRIB_API = 'iris_grib._save_rules.eccodes'
 GRIB_MESSAGE = mock.sentinel.GRIB_MESSAGE
 
 
 class TestMDI(tests.IrisGribTest):
     def assertBitmapOff(self, grib_api):
         # Check the use of a mask has been turned off via:
-        #   gribapi.grib_set(grib_message, 'bitmapPresent', 0)
-        grib_api.grib_set.assert_called_once_with(GRIB_MESSAGE,
+        #   eccodes.codes_set(grib_message, 'bitmapPresent', 0)
+        grib_api.codes_set.assert_called_once_with(GRIB_MESSAGE,
                                                   'bitmapPresent', 0)
 
     def assertBitmapOn(self, grib_api, fill_value):
         # Check the use of a mask has been turned on via:
-        #   gribapi.grib_set(grib_message, 'bitmapPresent', 1)
-        #   gribapi.grib_set_double(grib_message, 'missingValue', fill_value)
-        grib_api.grib_set.assert_called_once_with(GRIB_MESSAGE,
+        #   eccodes.codes_set(grib_message, 'bitmapPresent', 1)
+        #   eccodes.codes_set_double(grib_message, 'missingValue', fill_value)
+        grib_api.codes_set.assert_called_once_with(GRIB_MESSAGE,
                                                   'bitmapPresent', 1)
-        grib_api.grib_set_double.assert_called_once_with(GRIB_MESSAGE,
+        grib_api.codes_set_double.assert_called_once_with(GRIB_MESSAGE,
                                                          'missingValue',
                                                          fill_value)
 
     def assertBitmapRange(self, grib_api, min_data, max_data):
         # Check the use of a mask has been turned on via:
-        #   gribapi.grib_set(grib_message, 'bitmapPresent', 1)
-        #   gribapi.grib_set_double(grib_message, 'missingValue', ...)
+        #   eccodes.codes_set(grib_message, 'bitmapPresent', 1)
+        #   eccodes.codes_set_double(grib_message, 'missingValue', ...)
         # and that a suitable fill value has been chosen.
-        grib_api.grib_set.assert_called_once_with(GRIB_MESSAGE,
+        grib_api.codes_set.assert_called_once_with(GRIB_MESSAGE,
                                                   'bitmapPresent', 1)
-        args, = grib_api.grib_set_double.call_args_list
+        args, = grib_api.codes_set_double.call_args_list
         (message, key, fill_value), kwargs = args
         self.assertIs(message, GRIB_MESSAGE)
         self.assertEqual(key, 'missingValue')
@@ -60,8 +60,8 @@ class TestMDI(tests.IrisGribTest):
 
     def assertValues(self, grib_api, values):
         # Check the correct data values have been set via:
-        #   gribapi.grib_set_double_array(grib_message, 'values', ...)
-        args, = grib_api.grib_set_double_array.call_args_list
+        #   eccodes.codes_set_double_array(grib_message, 'values', ...)
+        args, = grib_api.codes_set_double_array.call_args_list
         (message, key, values), kwargs = args
         self.assertIs(message, GRIB_MESSAGE)
         self.assertEqual(key, 'values')
@@ -160,9 +160,9 @@ class TestNonDoubleData(tests.IrisGribTest):
         data = np.random.random(1920 * 2560).astype(dtype)
         cube = iris.cube.Cube(data,
                               standard_name='geopotential_height', units='km')
-        grib_message = gribapi.grib_new_from_samples("GRIB2")
+        grib_message = eccodes.codes_grib_new_from_samples("GRIB2")
         data_section(cube, grib_message)
-        gribapi.grib_release(grib_message)
+        eccodes.codes_release(grib_message)
 
     def test_float32(self):
         self.check(dtype=np.float32)

--- a/iris_grib/tests/unit/save_rules/test_data_section.py
+++ b/iris_grib/tests/unit/save_rules/test_data_section.py
@@ -30,17 +30,17 @@ class TestMDI(tests.IrisGribTest):
         # Check the use of a mask has been turned off via:
         #   eccodes.codes_set(grib_message, 'bitmapPresent', 0)
         grib_api.codes_set.assert_called_once_with(GRIB_MESSAGE,
-                                                  'bitmapPresent', 0)
+                                                   'bitmapPresent', 0)
 
     def assertBitmapOn(self, grib_api, fill_value):
         # Check the use of a mask has been turned on via:
         #   eccodes.codes_set(grib_message, 'bitmapPresent', 1)
         #   eccodes.codes_set_double(grib_message, 'missingValue', fill_value)
         grib_api.codes_set.assert_called_once_with(GRIB_MESSAGE,
-                                                  'bitmapPresent', 1)
+                                                   'bitmapPresent', 1)
         grib_api.codes_set_double.assert_called_once_with(GRIB_MESSAGE,
-                                                         'missingValue',
-                                                         fill_value)
+                                                          'missingValue',
+                                                          fill_value)
 
     def assertBitmapRange(self, grib_api, min_data, max_data):
         # Check the use of a mask has been turned on via:
@@ -48,7 +48,7 @@ class TestMDI(tests.IrisGribTest):
         #   eccodes.codes_set_double(grib_message, 'missingValue', ...)
         # and that a suitable fill value has been chosen.
         grib_api.codes_set.assert_called_once_with(GRIB_MESSAGE,
-                                                  'bitmapPresent', 1)
+                                                   'bitmapPresent', 1)
         args, = grib_api.codes_set_double.call_args_list
         (message, key, fill_value), kwargs = args
         self.assertIs(message, GRIB_MESSAGE)

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_12.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_12.py
@@ -102,15 +102,15 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         self._check_key("Di", 200)
         self._check_key("Dj", 500)
 
-    def test__negative_grid_points_gribapi_broken(self):
-        self.mock_gribapi.GribInternalError = FakeGribError
+    def test__negative_grid_points_eccodes_broken(self):
+        self.mock_eccodes.GribInternalError = FakeGribError
 
         # Force the test to run the signed int --> unsigned int workaround.
         def set(grib, key, value):
             if key in ["X1", "X2", "Y1", "Y2"] and value < 0:
-                raise self.mock_gribapi.GribInternalError()
+                raise self.mock_eccodes.GribInternalError()
             grib.keys[key] = value
-        self.mock_gribapi.grib_set = set
+        self.mock_eccodes.codes_set = set
 
         test_cube = self._make_test_cube(x_points=[-1, 1, 3, 5, 7],
                                          y_points=[-4, 9])
@@ -120,7 +120,7 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         self._check_key("Y1", 0x80000190)
         self._check_key("Y2", 900)
 
-    def test__negative_grid_points_gribapi_fixed(self):
+    def test__negative_grid_points_eccodes_fixed(self):
         test_cube = self._make_test_cube(x_points=[-1, 1, 3, 5, 7],
                                          y_points=[-4, 9])
         grid_definition_template_12(test_cube, self.mock_grib)
@@ -136,7 +136,7 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         self._check_key("XR", 40000000.0)
         self._check_key("YR", -10000000.0)
 
-    def test__scale_factor_gribapi_broken(self):
+    def test__scale_factor_eccodes_broken(self):
         # GRIBAPI expects a signed int for scaleFactorAtReferencePoint
         # but it should accept a float, so work around this.
         # See https://software.ecmwf.int/issues/browse/SUP-1100
@@ -144,16 +144,16 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         def get_native_type(grib, key):
             assert key == "scaleFactorAtReferencePoint"
             return int
-        self.mock_gribapi.grib_get_native_type = get_native_type
+        self.mock_eccodes.codes_get_native_type = get_native_type
         grid_definition_template_12(self.test_cube, self.mock_grib)
         self._check_key("scaleFactorAtReferencePoint", 1065346526)
 
-    def test__scale_factor_gribapi_fixed(self):
+    def test__scale_factor_eccodes_fixed(self):
 
         def get_native_type(grib, key):
             assert key == "scaleFactorAtReferencePoint"
             return float
-        self.mock_gribapi.grib_get_native_type = get_native_type
+        self.mock_eccodes.codes_get_native_type = get_native_type
         grid_definition_template_12(self.test_cube, self.mock_grib)
         self._check_key("scaleFactorAtReferencePoint", 0.9996012717)
 

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_12.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_12.py
@@ -103,12 +103,12 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         self._check_key("Dj", 500)
 
     def test__negative_grid_points_eccodes_broken(self):
-        self.mock_eccodes.GribInternalError = FakeGribError
+        self.mock_eccodes.CodesInternalError = FakeGribError
 
         # Force the test to run the signed int --> unsigned int workaround.
         def set(grib, key, value):
             if key in ["X1", "X2", "Y1", "Y2"] and value < 0:
-                raise self.mock_eccodes.GribInternalError()
+                raise self.mock_eccodes.CodesInternalError()
             grib.keys[key] = value
         self.mock_eccodes.codes_set = set
 

--- a/iris_grib/tests/unit/save_rules/test_identification.py
+++ b/iris_grib/tests/unit/save_rules/test_identification.py
@@ -11,7 +11,7 @@ import iris_grib.tests as tests
 
 from unittest import mock
 
-import gribapi
+import eccodes
 
 import iris
 import iris.tests.stock as stock
@@ -20,7 +20,7 @@ from iris_grib._save_rules import identification
 from iris_grib.tests.unit import TestGribSimple
 
 
-GRIB_API = 'iris_grib._save_rules.gribapi'
+GRIB_API = 'iris_grib._save_rules.eccodes'
 
 
 class Test(TestGribSimple):
@@ -28,12 +28,12 @@ class Test(TestGribSimple):
     def test_no_realization(self):
         cube = stock.simple_pp()
         grib = mock.Mock()
-        mock_gribapi = mock.Mock(spec=gribapi)
-        with mock.patch(GRIB_API, mock_gribapi):
+        mock_eccodes = mock.Mock(spec=eccodes)
+        with mock.patch(GRIB_API, mock_eccodes):
             identification(cube, grib)
 
-        mock_gribapi.assert_has_calls(
-            [mock.call.grib_set_long(grib, "typeOfProcessedData", 2)])
+        mock_eccodes.assert_has_calls(
+            [mock.call.codes_set_long(grib, "typeOfProcessedData", 2)])
 
     @tests.skip_data
     def test_realization_0(self):
@@ -43,12 +43,12 @@ class Test(TestGribSimple):
         cube.add_aux_coord(realisation)
 
         grib = mock.Mock()
-        mock_gribapi = mock.Mock(spec=gribapi)
-        with mock.patch(GRIB_API, mock_gribapi):
+        mock_eccodes = mock.Mock(spec=eccodes)
+        with mock.patch(GRIB_API, mock_eccodes):
             identification(cube, grib)
 
-        mock_gribapi.assert_has_calls(
-            [mock.call.grib_set_long(grib, "typeOfProcessedData", 3)])
+        mock_eccodes.assert_has_calls(
+            [mock.call.codes_set_long(grib, "typeOfProcessedData", 3)])
 
     @tests.skip_data
     def test_realization_n(self):
@@ -58,12 +58,12 @@ class Test(TestGribSimple):
         cube.add_aux_coord(realisation)
 
         grib = mock.Mock()
-        mock_gribapi = mock.Mock(spec=gribapi)
-        with mock.patch(GRIB_API, mock_gribapi):
+        mock_eccodes = mock.Mock(spec=eccodes)
+        with mock.patch(GRIB_API, mock_eccodes):
             identification(cube, grib)
 
-        mock_gribapi.assert_has_calls(
-            [mock.call.grib_set_long(grib, "typeOfProcessedData", 4)])
+        mock_eccodes.assert_has_calls(
+            [mock.call.codes_set_long(grib, "typeOfProcessedData", 4)])
 
 
 if __name__ == "__main__":

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_1.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_1.py
@@ -15,7 +15,7 @@ import iris_grib.tests as tests
 from unittest import mock
 
 from cf_units import Unit
-import gribapi
+import eccodes
 
 from iris.coords import DimCoord
 import iris.tests.stock as stock
@@ -32,7 +32,7 @@ class TestRealizationIdentifier(tests.IrisGribTest):
                          units=Unit('days since epoch', calendar='standard'))
         self.cube.add_aux_coord(coord)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_realization(self, mock_set):
         cube = self.cube
         coord = DimCoord(10, 'realization', units='1')
@@ -48,7 +48,7 @@ class TestRealizationIdentifier(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "typeOfEnsembleForecast", 255)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_multiple_realization_values(self, mock_set):
         cube = self.cube
         coord = DimCoord([8, 9, 10], 'realization', units='1')

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_10.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_10.py
@@ -15,7 +15,7 @@ import iris_grib.tests as tests
 from unittest import mock
 
 from cf_units import Unit
-import gribapi
+import eccodes
 
 from iris.coords import DimCoord
 import iris.tests.stock as stock
@@ -33,7 +33,7 @@ class TestPercentileValueIdentifier(tests.IrisGribTest):
             units=Unit('days since epoch', calendar='julian'))
         self.cube.add_aux_coord(time_coord)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_percentile_value(self, mock_set):
         cube = self.cube
         percentile_coord = DimCoord(95, long_name='percentile_over_time')
@@ -45,7 +45,7 @@ class TestPercentileValueIdentifier(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "percentileValue", 95)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_multiple_percentile_value(self, mock_set):
         cube = self.cube
         percentile_coord = DimCoord([5, 10, 15],

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_11.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_11.py
@@ -15,7 +15,7 @@ import iris_grib.tests as tests
 from unittest import mock
 
 from cf_units import Unit
-import gribapi
+import eccodes
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock
@@ -34,7 +34,7 @@ class TestRealizationIdentifier(tests.IrisGribTest):
         coord = DimCoord(4, 'realization', units='1')
         self.cube.add_aux_coord(coord)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_realization(self, mock_set):
         cube = self.cube
         cell_method = CellMethod(method='sum', coords=['time'])

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_15.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_15.py
@@ -15,7 +15,7 @@ import iris_grib.tests as tests
 from unittest import mock
 
 from cf_units import Unit
-import gribapi
+import eccodes
 
 from iris.coords import CellMethod, DimCoord
 import iris.tests.stock as stock
@@ -35,7 +35,7 @@ class TestSpatialProcessingIdentifiers(tests.IrisGribTest):
         # Rename cube to avoid warning about unknown discipline/parameter.
         self.cube.rename('air_temperature')
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_cell_method(self, mock_set):
         cube_0 = self.cube
         cube_0.attributes = dict(spatial_processing_type='No interpolation')
@@ -53,7 +53,7 @@ class TestSpatialProcessingIdentifiers(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "statisticalProcess", 0)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_bilinear_interpolation(self, mock_set):
         cube_1 = self.cube
         cube_1.attributes = dict(spatial_processing_type='Bilinear '
@@ -69,7 +69,7 @@ class TestSpatialProcessingIdentifiers(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "numberOfPointsUsed", 4)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_bicubic_interpolation(self, mock_set):
         cube_2 = self.cube
         cube_2.attributes = dict(spatial_processing_type='Bicubic '
@@ -85,7 +85,7 @@ class TestSpatialProcessingIdentifiers(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "numberOfPointsUsed", 4)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_nearest_neighbour_interpolation(self, mock_set):
         cube_3 = self.cube
         cube_3.attributes = dict(spatial_processing_type='Nearest neighbour '
@@ -101,7 +101,7 @@ class TestSpatialProcessingIdentifiers(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "numberOfPointsUsed", 1)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_budget_interpolation(self, mock_set):
         cube_4 = self.cube
         cube_4.attributes = dict(spatial_processing_type='Budget '
@@ -117,7 +117,7 @@ class TestSpatialProcessingIdentifiers(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "numberOfPointsUsed", 4)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_spectral_interpolation(self, mock_set):
         cube_5 = self.cube
         cube_5.attributes = dict(spatial_processing_type='Spectral '
@@ -133,7 +133,7 @@ class TestSpatialProcessingIdentifiers(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  "numberOfPointsUsed", 4)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_neighbour_budget_interpolation(self, mock_set):
         cube_6 = self.cube
         cube_6.attributes = dict(spatial_processing_type='Neighbour-budget '

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_40.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_40.py
@@ -15,7 +15,7 @@ import iris_grib.tests as tests
 from unittest import mock
 
 from cf_units import Unit
-import gribapi
+import eccodes
 
 from iris.coords import DimCoord
 import iris.tests.stock as stock
@@ -33,7 +33,7 @@ class TestChemicalConstituentIdentifier(tests.IrisGribTest):
         self.cube.add_aux_coord(coord)
         self.cube.attributes['WMO_constituent_type'] = 0
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_constituent_type(self, mock_set):
         cube = self.cube
 

--- a/iris_grib/tests/unit/save_rules/test_product_definition_template_8.py
+++ b/iris_grib/tests/unit/save_rules/test_product_definition_template_8.py
@@ -15,7 +15,7 @@ import iris_grib.tests as tests
 from unittest import mock
 
 from cf_units import Unit
-import gribapi
+import eccodes
 import numpy as np
 
 from iris.coords import CellMethod, DimCoord
@@ -34,7 +34,7 @@ class TestProductDefinitionIdentifier(tests.IrisGribTest):
                          units=Unit('days since epoch', calendar='standard'))
         self.cube.add_aux_coord(coord)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_product_definition(self, mock_set):
         cube = self.cube
         cell_method = CellMethod(method='sum', coords=['time'])
@@ -46,7 +46,7 @@ class TestProductDefinitionIdentifier(tests.IrisGribTest):
 
 
 class Test_type_of_statistical_processing(tests.IrisTest):
-    @mock.patch.object(gribapi, "grib_set")
+    @mock.patch.object(eccodes, "codes_set")
     def test_stats_type_min(self, mock_set):
         grib = None
         cube = iris.cube.Cube(np.array([1.0]))
@@ -59,7 +59,7 @@ class Test_type_of_statistical_processing(tests.IrisTest):
         product_definition_template_8(cube, grib)
         mock_set.assert_any_call(grib, "typeOfStatisticalProcessing", 2)
 
-    @mock.patch.object(gribapi, "grib_set")
+    @mock.patch.object(eccodes, "codes_set")
     def test_stats_type_max(self, mock_set):
         grib = None
         cube = iris.cube.Cube(np.array([1.0]))

--- a/iris_grib/tests/unit/save_rules/test_reference_time.py
+++ b/iris_grib/tests/unit/save_rules/test_reference_time.py
@@ -11,7 +11,7 @@ import iris_grib.tests as tests
 
 from unittest import mock
 
-import gribapi
+import eccodes
 
 from iris_grib import load_cubes
 from iris_grib._save_rules import reference_time
@@ -20,14 +20,14 @@ from iris_grib._save_rules import reference_time
 class Test(tests.IrisGribTest):
     def _test(self, cube):
         grib = mock.Mock()
-        mock_gribapi = mock.Mock(spec=gribapi)
-        with mock.patch('iris_grib._save_rules.gribapi', mock_gribapi):
+        mock_eccodes = mock.Mock(spec=eccodes)
+        with mock.patch('iris_grib._save_rules.eccodes', mock_eccodes):
             reference_time(cube, grib)
 
-        mock_gribapi.assert_has_calls(
-            [mock.call.grib_set_long(grib, "significanceOfReferenceTime", 1),
-             mock.call.grib_set_long(grib, "dataDate", '19980306'),
-             mock.call.grib_set_long(grib, "dataTime", '0300')])
+        mock_eccodes.assert_has_calls(
+            [mock.call.codes_set_long(grib, "significanceOfReferenceTime", 1),
+             mock.call.codes_set_long(grib, "dataDate", '19980306'),
+             mock.call.codes_set_long(grib, "dataTime", '0300')])
 
     @tests.skip_data
     def test_forecast_period(self):

--- a/iris_grib/tests/unit/save_rules/test_set_discipline_and_parameter.py
+++ b/iris_grib/tests/unit/save_rules/test_set_discipline_and_parameter.py
@@ -27,8 +27,8 @@ class TestPhenomenonCoding(tests.IrisGribTest):
 
     def _check_coding(self, cube, discipline, paramCategory, paramNumber):
         # Check that encoding 'cube' writes the expected phenomenon keys.
-        grib_set_patch = self.patch(
-            'iris_grib._save_rules.gribapi.grib_set')
+        codes_set_patch = self.patch(
+            'iris_grib._save_rules.eccodes.codes_set')
         mock_message = mock.sentinel.grib2_message
 
         set_discipline_and_parameter(cube, mock_message)
@@ -38,7 +38,7 @@ class TestPhenomenonCoding(tests.IrisGribTest):
             mock.call(mock_message, "parameterCategory", paramCategory),
             mock.call(mock_message, "parameterNumber", paramNumber)]
 
-        self.assertEqual(grib_set_patch.call_args_list, expected_calls)
+        self.assertEqual(codes_set_patch.call_args_list, expected_calls)
 
     def test_unknown_phenomenon(self):
         cube = self.mock_cube

--- a/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
+++ b/iris_grib/tests/unit/save_rules/test_set_fixed_surfaces.py
@@ -14,8 +14,8 @@ import iris_grib.tests as tests
 
 from unittest import mock
 
-import gribapi
-from gribapi import GRIB_MISSING_LONG
+import eccodes
+from eccodes import CODES_MISSING_LONG as GRIB_MISSING_LONG
 import numpy as np
 
 import iris.cube
@@ -30,19 +30,19 @@ class Test(tests.IrisGribTest):
         cube.add_aux_coord(iris.coords.AuxCoord(
             1500.0, long_name='altitude', units='ft',
             bounds=np.array([1000.0, 2000.0])))
-        grib = gribapi.grib_new_from_samples("GRIB2")
+        grib = eccodes.codes_grib_new_from_samples("GRIB2")
         set_fixed_surfaces(cube, grib)
         self.assertEqual(
-            gribapi.grib_get_double(grib, "scaledValueOfFirstFixedSurface"),
+            eccodes.codes_get_double(grib, "scaledValueOfFirstFixedSurface"),
             305.0)  # precise ~304.8
         self.assertEqual(
-            gribapi.grib_get_double(grib, "scaledValueOfSecondFixedSurface"),
+            eccodes.codes_get_double(grib, "scaledValueOfSecondFixedSurface"),
             610.0)  # precise ~609.6
         self.assertEqual(
-            gribapi.grib_get_long(grib, "typeOfFirstFixedSurface"),
+            eccodes.codes_get_long(grib, "typeOfFirstFixedSurface"),
             102)
         self.assertEqual(
-            gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
+            eccodes.codes_get_long(grib, "typeOfSecondFixedSurface"),
             102)
 
     def test_theta_level(self):
@@ -51,19 +51,19 @@ class Test(tests.IrisGribTest):
             230.0, standard_name='air_potential_temperature',
             units='K', attributes={'positive': 'up'},
             bounds=np.array([220.0, 240.0])))
-        grib = gribapi.grib_new_from_samples("GRIB2")
+        grib = eccodes.codes_grib_new_from_samples("GRIB2")
         set_fixed_surfaces(cube, grib)
         self.assertEqual(
-            gribapi.grib_get_double(grib, "scaledValueOfFirstFixedSurface"),
+            eccodes.codes_get_double(grib, "scaledValueOfFirstFixedSurface"),
             220.0)
         self.assertEqual(
-            gribapi.grib_get_double(grib, "scaledValueOfSecondFixedSurface"),
+            eccodes.codes_get_double(grib, "scaledValueOfSecondFixedSurface"),
             240.0)
         self.assertEqual(
-            gribapi.grib_get_long(grib, "typeOfFirstFixedSurface"),
+            eccodes.codes_get_long(grib, "typeOfFirstFixedSurface"),
             107)
         self.assertEqual(
-            gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
+            eccodes.codes_get_long(grib, "typeOfSecondFixedSurface"),
             107)
 
     def test_depth(self):
@@ -71,22 +71,22 @@ class Test(tests.IrisGribTest):
         cube.add_aux_coord(iris.coords.AuxCoord(
             1, long_name='depth', units='m',
             bounds=np.array([0., 2]), attributes={'positive': 'down'}))
-        grib = gribapi.grib_new_from_samples("GRIB2")
+        grib = eccodes.codes_grib_new_from_samples("GRIB2")
         set_fixed_surfaces(cube, grib)
         self.assertEqual(
-            gribapi.grib_get_double(grib, "scaledValueOfFirstFixedSurface"),
+            eccodes.codes_get_double(grib, "scaledValueOfFirstFixedSurface"),
             0.)
         self.assertEqual(
-            gribapi.grib_get_double(grib, "scaledValueOfSecondFixedSurface"),
+            eccodes.codes_get_double(grib, "scaledValueOfSecondFixedSurface"),
             2)
         self.assertEqual(
-            gribapi.grib_get_long(grib, "typeOfFirstFixedSurface"),
+            eccodes.codes_get_long(grib, "typeOfFirstFixedSurface"),
             106)
         self.assertEqual(
-            gribapi.grib_get_long(grib, "typeOfSecondFixedSurface"),
+            eccodes.codes_get_long(grib, "typeOfSecondFixedSurface"),
             106)
 
-    @mock.patch.object(gribapi, "grib_set")
+    @mock.patch.object(eccodes, "codes_set")
     def test_altitude_point(self, mock_set):
         grib = None
         cube = iris.cube.Cube([1, 2, 3, 4, 5])
@@ -106,7 +106,7 @@ class Test(tests.IrisGribTest):
         mock_set.assert_any_call(grib, "scaledValueOfSecondFixedSurface",
                                  GRIB_MISSING_LONG)
 
-    @mock.patch.object(gribapi, "grib_set")
+    @mock.patch.object(eccodes, "codes_set")
     def test_height_point(self, mock_set):
         grib = None
         cube = iris.cube.Cube([1, 2, 3, 4, 5])
@@ -122,7 +122,7 @@ class Test(tests.IrisGribTest):
         mock_set.assert_any_call(grib, "scaledValueOfSecondFixedSurface",
                                  GRIB_MISSING_LONG)
 
-    @mock.patch.object(gribapi, "grib_set")
+    @mock.patch.object(eccodes, "codes_set")
     def test_no_vertical(self, mock_set):
         grib = None
         cube = iris.cube.Cube([1, 2, 3, 4, 5])

--- a/iris_grib/tests/unit/save_rules/test_set_time_increment.py
+++ b/iris_grib/tests/unit/save_rules/test_set_time_increment.py
@@ -14,7 +14,7 @@ import iris_grib.tests as tests
 
 from unittest import mock
 
-import gribapi
+import eccodes
 
 from iris.coords import CellMethod
 
@@ -22,7 +22,7 @@ from iris_grib._save_rules import set_time_increment
 
 
 class Test(tests.IrisGribTest):
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_no_intervals(self, mock_set):
         cell_method = CellMethod('sum', 'time')
         set_time_increment(cell_method, mock.sentinel.grib)
@@ -30,7 +30,7 @@ class Test(tests.IrisGribTest):
                                  'indicatorOfUnitForTimeIncrement', 255)
         mock_set.assert_any_call(mock.sentinel.grib, 'timeIncrement', 0)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_area(self, mock_set):
         cell_method = CellMethod('sum', 'area', '25 km')
         set_time_increment(cell_method, mock.sentinel.grib)
@@ -38,7 +38,7 @@ class Test(tests.IrisGribTest):
                                  'indicatorOfUnitForTimeIncrement', 255)
         mock_set.assert_any_call(mock.sentinel.grib, 'timeIncrement', 0)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_multiple_intervals(self, mock_set):
         cell_method = CellMethod('sum', 'time', ('1 hour', '24 hour'))
         set_time_increment(cell_method, mock.sentinel.grib)
@@ -46,7 +46,7 @@ class Test(tests.IrisGribTest):
                                  'indicatorOfUnitForTimeIncrement', 255)
         mock_set.assert_any_call(mock.sentinel.grib, 'timeIncrement', 0)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_hr(self, mock_set):
         cell_method = CellMethod('sum', 'time', '23 hr')
         set_time_increment(cell_method, mock.sentinel.grib)
@@ -54,7 +54,7 @@ class Test(tests.IrisGribTest):
                                  'indicatorOfUnitForTimeIncrement', 1)
         mock_set.assert_any_call(mock.sentinel.grib, 'timeIncrement', 23)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_hour(self, mock_set):
         cell_method = CellMethod('sum', 'time', '24 hour')
         set_time_increment(cell_method, mock.sentinel.grib)
@@ -62,7 +62,7 @@ class Test(tests.IrisGribTest):
                                  'indicatorOfUnitForTimeIncrement', 1)
         mock_set.assert_any_call(mock.sentinel.grib, 'timeIncrement', 24)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_hours(self, mock_set):
         cell_method = CellMethod('sum', 'time', '25 hours')
         set_time_increment(cell_method, mock.sentinel.grib)
@@ -70,7 +70,7 @@ class Test(tests.IrisGribTest):
                                  'indicatorOfUnitForTimeIncrement', 1)
         mock_set.assert_any_call(mock.sentinel.grib, 'timeIncrement', 25)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_fractional_hours(self, mock_set):
         cell_method = CellMethod('sum', 'time', '25.9 hours')
         with mock.patch('warnings.warn') as warn:

--- a/iris_grib/tests/unit/save_rules/test_set_time_range.py
+++ b/iris_grib/tests/unit/save_rules/test_set_time_range.py
@@ -16,7 +16,7 @@ from unittest import mock
 import warnings
 
 from cf_units import Unit
-import gribapi
+import eccodes
 
 from iris.coords import DimCoord
 
@@ -47,7 +47,7 @@ class Test(tests.IrisGribTest):
                                     'coordinate, got 2 points'):
             set_time_range(coord, mock.sentinel.grib)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_hours(self, mock_set):
         lower = 10
         upper = 20
@@ -58,7 +58,7 @@ class Test(tests.IrisGribTest):
         mock_set.assert_any_call(mock.sentinel.grib,
                                  'lengthOfTimeRange', upper - lower)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_days(self, mock_set):
         lower = 4
         upper = 6
@@ -71,7 +71,7 @@ class Test(tests.IrisGribTest):
                                  'lengthOfTimeRange',
                                  (upper - lower) * 24)
 
-    @mock.patch.object(gribapi, 'grib_set')
+    @mock.patch.object(eccodes, 'codes_set')
     def test_fractional_hours(self, mock_set_long):
         lower = 10.0
         upper = 20.9

--- a/iris_grib/tests/unit/test_GribWrapper.py
+++ b/iris_grib/tests/unit/test_GribWrapper.py
@@ -24,7 +24,7 @@ from iris_grib import GribWrapper, _load_generate
 _message_length = 1000
 
 
-def _mock_grib_get_long(grib_message, key):
+def _mock_codes_get_long(grib_message, key):
     lookup = dict(totalLength=_message_length,
                   numberOfValues=200,
                   jPointsAreConsecutive=0,
@@ -34,16 +34,16 @@ def _mock_grib_get_long(grib_message, key):
     try:
         result = lookup[key]
     except KeyError:
-        msg = 'Mock grib_get_long unknown key: {!r}'.format(key)
+        msg = 'Mock codes_get_long unknown key: {!r}'.format(key)
         raise AttributeError(msg)
     return result
 
 
-def _mock_grib_get_string(grib_message, key):
+def _mock_codes_get_string(grib_message, key):
     return grib_message
 
 
-def _mock_grib_get_native_type(grib_message, key):
+def _mock_codes_get_native_type(grib_message, key):
     result = int
     if key == 'gridType':
         result = str
@@ -54,9 +54,9 @@ class Test_edition(tests.IrisGribTest):
     def setUp(self):
         self.patch('iris_grib.GribWrapper._confirm_in_scope')
         self.patch('iris_grib.GribWrapper._compute_extra_keys')
-        self.patch('gribapi.grib_get_long', _mock_grib_get_long)
-        self.patch('gribapi.grib_get_string', _mock_grib_get_string)
-        self.patch('gribapi.grib_get_native_type', _mock_grib_get_native_type)
+        self.patch('eccodes.codes_get_long', _mock_codes_get_long)
+        self.patch('eccodes.codes_get_string', _mock_codes_get_string)
+        self.patch('eccodes.codes_get_native_type', _mock_codes_get_native_type)
         self.tell = mock.Mock(side_effect=[_message_length])
 
     def test_not_edition_1(self):
@@ -64,7 +64,7 @@ class Test_edition(tests.IrisGribTest):
             return 2
 
         emsg = "GRIB edition 2 is not supported by 'GribWrapper'"
-        with mock.patch('gribapi.grib_get_long', func):
+        with mock.patch('eccodes.codes_get_long', func):
             with self.assertRaisesRegex(TranslationError, emsg):
                 GribWrapper(None)
 
@@ -94,15 +94,15 @@ class Test_deferred_proxy_args(tests.IrisTest):
     def setUp(self):
         self.patch('iris_grib.GribWrapper._confirm_in_scope')
         self.patch('iris_grib.GribWrapper._compute_extra_keys')
-        self.patch('gribapi.grib_get_long', _mock_grib_get_long)
-        self.patch('gribapi.grib_get_string', _mock_grib_get_string)
-        self.patch('gribapi.grib_get_native_type', _mock_grib_get_native_type)
+        self.patch('eccodes.codes_get_long', _mock_codes_get_long)
+        self.patch('eccodes.codes_get_string', _mock_codes_get_string)
+        self.patch('eccodes.codes_get_native_type', _mock_codes_get_native_type)
         tell_tale = np.arange(1, 5) * _message_length
         self.expected = tell_tale - _message_length
         self.grib_fh = mock.Mock(tell=mock.Mock(side_effect=tell_tale))
         self.dtype = np.float64
         self.path = self.grib_fh.name
-        self.lookup = _mock_grib_get_long
+        self.lookup = _mock_codes_get_long
 
     def test_regular_proxy_args(self):
         grib_message = 'regular_ll'

--- a/iris_grib/tests/unit/test_GribWrapper.py
+++ b/iris_grib/tests/unit/test_GribWrapper.py
@@ -56,7 +56,8 @@ class Test_edition(tests.IrisGribTest):
         self.patch('iris_grib.GribWrapper._compute_extra_keys')
         self.patch('eccodes.codes_get_long', _mock_codes_get_long)
         self.patch('eccodes.codes_get_string', _mock_codes_get_string)
-        self.patch('eccodes.codes_get_native_type', _mock_codes_get_native_type)
+        self.patch('eccodes.codes_get_native_type',
+                   _mock_codes_get_native_type)
         self.tell = mock.Mock(side_effect=[_message_length])
 
     def test_not_edition_1(self):
@@ -96,7 +97,8 @@ class Test_deferred_proxy_args(tests.IrisTest):
         self.patch('iris_grib.GribWrapper._compute_extra_keys')
         self.patch('eccodes.codes_get_long', _mock_codes_get_long)
         self.patch('eccodes.codes_get_string', _mock_codes_get_string)
-        self.patch('eccodes.codes_get_native_type', _mock_codes_get_native_type)
+        self.patch('eccodes.codes_get_native_type',
+                   _mock_codes_get_native_type)
         tell_tale = np.arange(1, 5) * _message_length
         self.expected = tell_tale - _message_length
         self.grib_fh = mock.Mock(tell=mock.Mock(side_effect=tell_tale))

--- a/iris_grib/tests/unit/test_save_messages.py
+++ b/iris_grib/tests/unit/test_save_messages.py
@@ -9,7 +9,7 @@
 # importing anything else.
 import iris_grib.tests as tests
 
-import gribapi
+import eccodes
 from unittest import mock
 
 import iris_grib
@@ -18,7 +18,7 @@ import iris_grib
 class TestSaveMessages(tests.IrisGribTest):
     def setUp(self):
         # Create a test object to stand in for a real PPField.
-        self.grib_message = gribapi.grib_new_from_samples("GRIB2")
+        self.grib_message = eccodes.codes_grib_new_from_samples("GRIB2")
 
     def test_save(self):
         m = mock.mock_open()


### PR DESCRIPTION
The [gribapi has been deprecated for a little while now](https://www.ecmwf.int/en/newsletter/152/news/end-road-grib-api) and replaced by [eccodes](). There's a bit of [guidance around the migration](https://confluence.ecmwf.int/display/ECC/GRIB-API+migration) but its pretty much a find/replace of `gribapi` -> `eccodes` and `grib_` -> `codes_`.

I've run the tests with the [current version of iris-test-data](https://github.com/SciTools/iris-test-data/tree/3306ae94956bc73b45576080a3ffb98ff9a9f1ad) and everything now passes.

There are a couple of references to early versions gribapi not handling certain use cases, but at the moment I've been unable to work out if they can be removed.