### PR TITLE
use workflows version for refresh-lockfiles ci

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   refresh_lockfiles:
-    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@main
+    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.03.0
     secrets: inherit


### PR DESCRIPTION
This PR pins the `refresh-lockfiles` GHA to a specific version of the [scitools/workflows](https://github.com/SciTools/workflows/releases/tag/2023.03.0).