### PR TITLE
replace deprecated `eccodes-python` PyPI package with new `eccodes` in core requirements

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
 # Core dependencies.
 
 scitools-iris>=3.0.2
-eccodes-python
+eccodes


### PR DESCRIPTION
PyPI's [`eccodes-python`](https://pypi.org/project/eccodes-python/) has now been deprecated and we are instructed to use `eccodes` instead (currently at 1.6.1 so please pin if needed).

Closes https://github.com/SciTools/iris-grib/issues/356

:beers: 