### PR TITLE
Drop deprecated distutils.version for packaging.version

### DIFF
--- a/iris_grib/_iris_mercator_support.py
+++ b/iris_grib/_iris_mercator_support.py
@@ -8,7 +8,7 @@ which iris-grib requires for its Mercator support.
 
 """
 
-import distutils.version
+from packaging.version import Version
 
 import iris
 
@@ -18,8 +18,8 @@ def confirm_extended_mercator_supported():
     # support in the Mercator coord-system.
     # This is a temporary fix allowing us to state Iris>=2.0 as a dependency,
     # required for this release because Iris 2.1 is not yet available.
-    iris_version = distutils.version.LooseVersion(iris.__version__)
-    min_mercator_version = '2.1.0'
+    iris_version = Version(iris.__version__)
+    min_mercator_version = Version('2.1.0')
     if iris_version < min_mercator_version:
         msg = 'Support for Mercator projections requires Iris version >= {}'
         raise ValueError(msg.format(min_mercator_version))


### PR DESCRIPTION
This pull-request addresses the following noisy deprecation warnings:

```bash
../iris-grib/iris_grib/_iris_mercator_support.py:21: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```
and
```bash
../site-packages/setuptools/_distutils/version.py:345: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```
Replacing the using of the deprecated `disutils.version` with `packaging.version` instead.