### PR TITLE
Fix for eccodes>=2.32.1 and python-eccodes>=1.6.1

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -315,9 +315,9 @@ def latlon_points_irregular(cube, grib):
     # So, this only works at present if the x and y dimensions are **equal**.
     lon_values = x_coord.points / _DEFAULT_DEGREES_UNITS
     lat_values = y_coord.points / _DEFAULT_DEGREES_UNITS
-    eccodes.codes_set_array(grib, 'longitudes',
+    eccodes.codes_set_array(grib, 'longitude',
                             np.array(np.round(lon_values), dtype=np.int64))
-    eccodes.codes_set_array(grib, 'latitudes',
+    eccodes.codes_set_array(grib, 'latitude',
                             np.array(np.round(lat_values), dtype=np.int64))
 
 

--- a/iris_grib/message.py
+++ b/iris_grib/message.py
@@ -413,17 +413,13 @@ class Section:
             if key == 'numberOfSection':
                 value = self._number
             else:
-                keys = [key]
-                # Also check known alias alternatives
-                if key in KEY_ALIAS:
-                    keys.append(KEY_ALIAS[key])
-                keys = np.array(keys)
-                found = [k in self._keys for k in keys]
-                if not any(found):
-                    emsg = f"{key} not defined in section {self._number}"
-                    raise KeyError(emsg)
-                # Take the first valid key, original or alias.
-                key = keys[found][0]
+                if key not in self._keys:
+                    key2 = KEY_ALIAS.get(key)
+                    if key2 and key2 in self._keys:
+                        key = key2
+                    else:
+                        emsg = f"{key} not defined in section {self._number}"
+                        raise KeyError(emsg)
                 value = self._get_key_value(key)
 
             self._cache[key] = value

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_4.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_4.py
@@ -62,8 +62,8 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         grid_definition_template_4(test_cube, self.mock_grib)
         x_longs = np.array(np.round(1e6 * x_floats), dtype=int)
         y_longs = np.array(np.round(1e6 * y_floats), dtype=int)
-        self._check_key("longitudes", x_longs)
-        self._check_key("latitudes", y_longs)
+        self._check_key("longitude", x_longs)
+        self._check_key("latitude", y_longs)
 
     def test__scanmode(self):
         grid_definition_template_4(self.test_cube, self.mock_grib)

--- a/iris_grib/tests/unit/save_rules/test_grid_definition_template_5.py
+++ b/iris_grib/tests/unit/save_rules/test_grid_definition_template_5.py
@@ -112,8 +112,8 @@ class Test(tests.IrisGribTest, GdtTestMixin):
         grid_definition_template_5(test_cube, self.mock_grib)
         x_longs = np.array(np.round(1e6 * x_floats), dtype=int)
         y_longs = np.array(np.round(1e6 * y_floats), dtype=int)
-        self._check_key("longitudes", x_longs)
-        self._check_key("latitudes", y_longs)
+        self._check_key("longitude", x_longs)
+        self._check_key("latitude", y_longs)
 
     def test__true_winds_orientation(self):
         self.test_cube.rename('eastward_wind')

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
 # Core dependencies.
 
 scitools-iris>=3.0.2
-eccodes-python
+eccodes>=1.6.1

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -11,7 +11,8 @@ dependencies:
 
 # Core dependencies.
   - iris>=3.0.2
-  - python-eccodes
+  - python-eccodes>=1.6.1
+  - eccodes>=2.32.1
 
 # Optional dependencies.
   - mo_pack

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -11,7 +11,8 @@ dependencies:
 
 # Core dependencies.
   - iris>=3.0.2
-  - python-eccodes
+  - python-eccodes>=1.6.1
+  - eccodes>=2.32.1
 
 # Optional dependencies.
   - mo_pack

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -11,7 +11,8 @@ dependencies:
 
 # Core dependencies.
   - iris>=3.0.2
-  - python-eccodes
+  - python-eccodes>=1.6.1
+  - eccodes>=2.32.1
 
 # Optional dependencies.
   - mo_pack


### PR DESCRIPTION
This pull-request updates `iris-grib` to cater within changes in the latest version of `eccodes`.

Due to this change in `eccodes` behaviour, I've defensively introduces a minimum pin for both `eccodes` and `python-eccodes`.

Note that, this PR is targeting the `auto-update-lockfiles` branch, which is the base branch of pull-request #354.