### PR TITLE
Fix the docs building on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,2 +1,32 @@
 conda:
-    file: requirements/readthedocs.yml
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: mambaforge-4.10
+  #jobs:
+    #post_checkout:
+      # The SciTools/iris repository is shallow i.e., has a .git/shallow,
+      # therefore complete the repository with a full history in order
+      # to allow setuptools-scm to correctly auto-discover the version.
+      #- git fetch --unshallow
+      #- git fetch --all
+    # Need to stash the local changes that Read the Docs makes so that
+    #  setuptools_scm can generate the correct Iris version.
+    #pre_install:
+    #  - git stash
+    #post_install:
+    #  - git stash pop
+
+conda:
+  environment: requirements/readthedocs.yml
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: requirements/readthedocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,19 +5,6 @@ build:
   os: ubuntu-20.04
   tools:
     python: mambaforge-4.10
-  #jobs:
-    #post_checkout:
-      # The SciTools/iris repository is shallow i.e., has a .git/shallow,
-      # therefore complete the repository with a full history in order
-      # to allow setuptools-scm to correctly auto-discover the version.
-      #- git fetch --unshallow
-      #- git fetch --all
-    # Need to stash the local changes that Read the Docs makes so that
-    #  setuptools_scm can generate the correct Iris version.
-    #pre_install:
-    #  - git stash
-    #post_install:
-    #  - git stash pop
 
 conda:
   environment: requirements/readthedocs.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,0 @@
-conda:
-    file: requirements/ci/readthedocs.yml

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -24,3 +24,11 @@ dependencies:
   - pep8
   - requests
   - nose
+
+# Documentation dependencies.
+  - sphinx 
+  #- sphinxcontrib-apidoc
+  #- sphinx-copybutton
+  #- sphinx-gallery >=0.11.0
+  #- sphinx-design
+  - sphinx_rtd_theme

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -27,8 +27,4 @@ dependencies:
 
 # Documentation dependencies.
   - sphinx 
-  #- sphinxcontrib-apidoc
-  #- sphinx-copybutton
-  #- sphinx-gallery >=0.11.0
-  #- sphinx-design
   - sphinx_rtd_theme


### PR DESCRIPTION
The docs have not been built successfully for a while.  This updates the `.readthedocs.yml` file.

Updates based upon the Iris config https://github.com/SciTools/iris/blob/main/.readthedocs.yml.  I think there was no need for the post checkout actions though so we removed.

Further tweaks may be needed but this will get it building cleanly.

I have also enabled readthedocs building the docs for PR's so this the docs should not go stale again.

Fix for https://github.com/SciTools/iris-grib/issues/365.