### PR TITLE
WIP GRIB2 table3.2 earth radius 6,371,229m

### DIFF
--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -211,6 +211,16 @@ def shape_of_the_earth(cube, grib):
         eccodes.codes_set_long(grib, "scaledValueOfEarthMajorAxis", 0)
         eccodes.codes_set_long(grib, "scaleFactorOfEarthMinorAxis", 0)
         eccodes.codes_set_long(grib, "scaledValueOfEarthMinorAxis", 0)
+    # Spherical earth.
+    elif (ellipsoid.semi_major_axis ==  6371229.0) and (ellipsoid.semi_minor_axis ==  6371229.0):
+        eccodes.codes_set_long(grib, "shapeOfTheEarth", 6)
+        eccodes.codes_set_long(grib, "scaleFactorOfRadiusOfSphericalEarth", 0)
+        eccodes.codes_set_long(grib, "scaledValueOfRadiusOfSphericalEarth",
+                               ellipsoid.semi_major_axis)
+        eccodes.codes_set_long(grib, "scaleFactorOfEarthMajorAxis", 0)
+        eccodes.codes_set_long(grib, "scaledValueOfEarthMajorAxis", 0)
+        eccodes.codes_set_long(grib, "scaleFactorOfEarthMinorAxis", 0)
+        eccodes.codes_set_long(grib, "scaledValueOfEarthMinorAxis", 0)
     # Oblate spheroid earth.
     else:
         eccodes.codes_set_long(grib, "shapeOfTheEarth", 7)


### PR DESCRIPTION
I may need guidance on how to get this across the line, I spotted a minor GRIB `shapeOfTheEarth` value related to a sphere with radius `6,371,229m` which should be value 6 from the following table:

https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table3-2.shtml
