### PR TITLE
Investigate unexpected licence check failures.

### DIFF
--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_20.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_20.py
@@ -1,5 +1,7 @@
 # Copyright iris-grib contributors
 #
+# MESS THIS UP
+#
 # This file is part of iris-grib and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 """

--- a/iris_grib/tests/unit/load_convert/test_grid_definition_template_40.py
+++ b/iris_grib/tests/unit/load_convert/test_grid_definition_template_40.py
@@ -8,6 +8,9 @@ Unit tests for
 
 """
 
+# MEANINGLESS CHANGE
+# - temporary tweak to force licence check on this file (otherwise unchanged).
+
 # import iris_grib.tests first so that some things can be initialised
 # before importing anything else.
 import iris_grib.tests as tests


### PR DESCRIPTION
I can't  any difference between the licence headers of `test_grid_definition_template_40.py` and `test_grid_definition_template_140.py`, but the latter is failing.

The header check only runs on files changed in the current commit (or something like).
So we shall see whether this fails on the old file (previously apparently OK) or not ...