### PR TITLE
v019x mergeback

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,3 @@
-conda:
 version: 2
 
 build:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ release = iris_grib.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -145,7 +145,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Iris-grib v0.18
+Iris-grib v0.19
 ===============
 
 The library ``iris-grib`` provides functionality for converting between weather and

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -1,24 +1,43 @@
 Release Notes
 =============
 
+What's new in iris-grib v0.19.1
+-------------------------------
+
+:Release: 0.19.1
+:Date: 14 December 2023
+
+Documentation
+^^^^^^^^^^^^^
+* `@pp-mo <https://github.com/pp-mo>`_ updated the release notes with v0.19 changes.
+  `(PR#370) <https://github.com/SciTools/iris-grib/pull/370>`_
+
 
 What's new in iris-grib v0.19.0
 -------------------------------
 
 :Release: 0.19.0
-:Date: [unreleased]
+:Date: 16 November 2023
 
+See also :
+`GitHub v0.19.0 release page <https://github.com/SciTools/iris-grib/releases/tag/v0.19.0>`_
 
-=======
 Features
 ^^^^^^^^
-* `@lbdreyer <https://github.com/lbdreyer>`_ and 
+* `@lbdreyer <https://github.com/lbdreyer>`_ and
   `@pp-mo <https://github.com/pp-mo>`_ (reviewer) modified the loading of GRIB
   messages with an unrecognised fixed surface type. These are now loaded in as
   an unnamed coordinate with an attribute called GRIB_fixed_surface_type.
   iris-grib will also save out cubes with this attribute as the given fixed
-  surface type.`(PR#318) <https://github.com/SciTools/iris-grib/pull/288>`_
+  surface type. `(PR#318) <https://github.com/SciTools/iris-grib/pull/318>`_
 
+* `@trexfeathers <https://github.com/trexfeathers>`_ extended Transverse Mercator
+  to support negative scanning.
+  `(PR#296) <https://github.com/SciTools/iris-grib/pull/296>`_
+
+* `@trexfeathers <https://github.com/trexfeathers>`_  added a number of new GRIB-CF
+  mappings, i.e. translations from GRIB parameters to CF standard names and vice-versa.
+  `(PR#297) <https://github.com/SciTools/iris-grib/pull/297>`_
 
 Bugs Fixed
 ^^^^^^^^^^
@@ -31,11 +50,36 @@ Bugs Fixed
   in Earth's radius will result in a different coordinate system and may also
   affect the coordinate values.
   `(PR#316) <https://github.com/SciTools/iris-grib/pull/316>`_
+* `@s-boardman <https://github.com/s-boardman>`_ corrected the calculation of bounded
+  forecast periods in GRIB1 loading.
+  `(PR#322) <https://github.com/SciTools/iris-grib/pull/322>`_
+* `@david-bentley <https://github.com/david-bentley>`_  fixed the calculation of message
+  file offsets to work in Windows as well as Linux, which was causing load failures.
+  `(PR#287) <https://github.com/SciTools/iris-grib/pull/287>`_
+* `@bjlittle <https://github.com/bjlittle>`_  fixed an error that occurred when a
+  message had all-missing data points.
+  `(PR#362) <https://github.com/SciTools/iris-grib/pull/362>`_
 
+
+Internal
+^^^^^^^^
+* `@lbdreyer <https://github.com/lbdreyer>`_ relicensed the repo from LGPL-3 to BSD-3.
+  `(PR#359) <https://github.com/SciTools/iris-grib/pull/359>`_
 
 Dependencies
 ^^^^^^^^^^^^
 * now requires Python version >= 3.9
+* replaced deprecated eccodes-python PyPI package with new eccodes by @valeriupredoi in #357
+* `@valeriupredoi <https://github.com/valeriupredoi>`_ replaced the deprecated
+  eccodes-python PyPI package with eccodes.
+  `(PR#357) <https://github.com/SciTools/iris-grib/pull/357>`_
+
+New Contributors
+^^^^^^^^^^^^^^^^
+Welcome to
+* `@s-boardman <https://github.com/s-boardman>`_
+* `@david-bentley <https://github.com/david-bentley>`_
+* `@valeriupredoi <https://github.com/valeriupredoi>`_
 
 
 What's new in iris-grib v0.18.0


### PR DESCRIPTION
**NOTE:** this is a mergeback, and could use a merge commit.

It seems this never got done after the v0.19 release, 
in consequence (for example) the docs on main currently still say it is [at version 0.18](https://github.com/SciTools/iris-grib/blob/b620e2e461706f21ec48a9ea6160514b4303cea0/docs/index.rst?plain=1#L6)