### PR TITLE
add iris-sample-data test dependency

### DIFF
--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -24,3 +24,4 @@ dependencies:
   - pep8
   - requests
   - nose
+  - iris-sample-data

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -24,6 +24,7 @@ dependencies:
   - pep8
   - requests
   - nose
+  - iris-sample-data
 
 # Documentation dependencies.
   - sphinx 

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -24,3 +24,4 @@ dependencies:
   - pep8
   - requests
   - nose
+  - iris-sample-data

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,5 @@ mock
 filelock
 pep8
 requests
+iris-sample-data
+


### PR DESCRIPTION
This pull-request adds the `iris-sample-data` package dependency, as required by doctests.