### PR TITLE
fix ci-tests nose workaround

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -37,13 +37,12 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.11"]
         session: ["doctest"]
-        # conda-forge doesn't fit within nose char limits, change with pytest
-        iris-source : ["condaforge"]
+        iris-source : ["conda-forge"]
         include:
           - os: "ubuntu-latest"
             python-version: "3.11"
             session: "tests"
-            iris-source: "condaforge"
+            iris-source: "conda-forge"
           - os: "ubuntu-latest"
             python-version: "3.11"
             session: "tests"
@@ -51,11 +50,11 @@ jobs:
           - os: "ubuntu-latest"
             python-version: "3.10"
             session: "tests"
-            iris-source: "condaforge"
+            iris-source: "conda-forge"
           - os: "ubuntu-latest"
             python-version: "3.9"
             session: "tests"
-            iris-source: "condaforge"
+            iris-source: "conda-forge"
 
     env:
       IRIS_TEST_DATA_VERSION: "2.24"

--- a/noxfile.py
+++ b/noxfile.py
@@ -163,7 +163,7 @@ def _install_and_cache_venv(session: nox.sessions.Session) -> None:
 
 @contextmanager
 def prepare_venv(
-    session: nox.sessions.Session, iris_source: str = 'conda_forge'
+    session: nox.sessions.Session, iris_source: str = 'conda-forge'
 ) -> None:
     """
     Create and cache the nox session conda environment, and additionally
@@ -177,7 +177,7 @@ def prepare_venv(
         A `nox.sessions.Session` object.
 
     iris_source: str
-        Determines where Iris was sourced from. Either 'conda_forge' (the
+        Determines where Iris was sourced from. Either 'conda-forge' (the
         default), or 'source' which refers to the Iris main branch.
 
     Notes
@@ -302,7 +302,7 @@ def tests(session: nox.sessions.Session, iris_source: str):
         A `nox.sessions.Session` object.
 
     iris_source: str
-        Either 'conda_forge' if using Iris from conda-forge, or 'source' if
+        Either 'conda-forge' if using Iris from conda-forge, or 'source' if
         installing Iris from the Iris' main branch.
 
     """


### PR DESCRIPTION
This PR undoes a temporary workaround introduced by #415 for a limitation encountered when using the `nose` package on a GHA runner.

As we have now migrated away from `nose` and are using `pytest`, this workaround is now no longer necessary 👍 