### PR TITLE
fix blacken-docs hook url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         types_or: [asciidoc, python, markdown, rst]
         additional_dependencies: [tomli]
 
--   repo: https://github.com/asottile/blacken-docs
+-   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
     -   id: blacken-docs


### PR DESCRIPTION
This pull-request changes to source URL for the `blacken-docs` pre-commit hook, as recommended by `repo-review`.

Resolves the following `repo-review` non-compliance:

![image](https://github.com/SciTools/iris-grib/assets/2051656/a58ee0b5-bb72-4da8-b1f4-09fcc0ceea2c)
