### PR TITLE
add pre-commit.ci message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+# See https://pre-commit.ci/#configuration
+# See https://github.com/scientific-python/cookie#sp-repo-review
+
+ci:
+  autofix_prs: false
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+
 
 files: |
     (?x)(


### PR DESCRIPTION
This pull-request customizes the `pre-commit.ci` pull-request message, and ensures that `pre-commit.ci` auto fixing is not enabled i.e., keep a human developer in the loop.

Simply add a comment with `pre-commit.ci autofix` on a pull request to manually trigger auto-fixing.

Resolves the following `repo-review` non-compliance:

![image](https://github.com/SciTools/iris-grib/assets/2051656/a79117b1-7244-4a5e-b797-42715d1ee032)

