### PR TITLE
adopt repo-review pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,13 @@ repos:
     hooks:
     - id: validate-pyproject
 
+-   repo: https://github.com/scientific-python/cookie
+    rev: 2024.03.10
+    hooks:
+    - id: sp-repo-review
+      additional_dependencies: ["repo-review[cli]"]
+      args: ["--show=errskip"]
+
 # TODO: pending the addition of numpydoc, including config file(s).
 #-   repo: https://github.com/numpy/numpydoc
 #    rev: v1.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ ignore = [
 # See https://mypy.readthedocs.io/en/stable/config_file.html
 ignore_missing_imports = true
 warn_unused_configs = true
+warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 exclude = [
     'noxfile\.py',
@@ -132,6 +133,18 @@ log_cli_level = "INFO"
 minversion = "6.0"
 testpaths = "src/iris_grib"
 xfail_strict = "True"
+
+[tool.repo-review]
+ignore = [
+    # https://learn.scientific-python.org/development/guides/style/#MY102
+    "MY102",  # MyPy show_error_codes deprecated
+    # https://learn.scientific-python.org/development/guides/style/#PC170
+    "PC170",  # Uses PyGrep hooks
+    # https://learn.scientific-python.org/development/guides/style/#PC180
+    "PC180",  # Uses prettier
+    # https://learn.scientific-python.org/development/guides/pytest/#PP309
+    "PP309",  # Filter warnings specified
+]
 
 [tool.ruff]
 # Exclude the following, in addition to the standard set of exclusions.


### PR DESCRIPTION
We have some exceptions to the rule (some of which we can address), but it's best that we adopt the `repo-review` hook now to ensure that we don't regress.