### PR TITLE
Provide masked/unmasked meta for calls to 'as_lazy_data' 

### DIFF
--- a/src/iris_grib/__init__.py
+++ b/src/iris_grib/__init__.py
@@ -153,6 +153,39 @@ class GribDataProxy:
             setattr(self, key, value)
 
 
+# Utility routines for the use of dask 'meta' in wrapping proxies
+def _aslazydata_has_meta():
+    """
+    Work out whether 'iris._lazy_data.as_lazy_data' takes a "meta" kwarg.
+
+    Up to Iris 3.8.0, "as_lazy_data" did not have a 'meta' keyword, but
+    since https://github.com/SciTools/iris/pull/5801, it now *requires* one,
+    if the wrapped object is anything other than a numpy or dask array.
+    """
+    from inspect import signature
+    from iris._lazy_data import as_lazy_data
+
+    sig = signature(as_lazy_data)
+    return "meta" in sig.parameters
+
+
+# Work this out just once.
+_ASLAZYDATA_NEEDS_META = _aslazydata_has_meta()
+
+
+def _make_dask_meta(shape, dtype, is_masked=True):
+    """
+    Construct a dask 'meta' object for use in 'dask.array.from_array'.
+
+    A "meta" array is made from the dtype and shape of the array-like to be
+    wrapped, plus whether it will return masked or unmasked data.
+    """
+    meta_shape = tuple([0 for _ in shape])
+    array_class = np.ma if is_masked else np
+    meta = array_class.zeros(meta_shape, dtype=dtype)
+    return meta
+
+
 class GribWrapper:
     """
     Contains a pygrib object plus some extra keys of our own.
@@ -198,7 +231,7 @@ class GribWrapper:
             dtype = np.dtype(float)  # Use default dtype for python float
             proxy = GribDataProxy(shape, dtype, grib_fh.name, offset)
             as_lazy_kwargs = {}
-            if _aslazydata_has_meta():
+            if _ASLAZYDATA_NEEDS_META:
                 meta = _make_dask_meta(shape, dtype, is_masked=has_bitmap)
                 as_lazy_kwargs["meta"] = meta
             self._data = as_lazy_data(proxy, **as_lazy_kwargs)
@@ -896,31 +929,3 @@ def save_messages(messages, target, append=False):
         # (this bit is common to the pp and grib savers...)
         if isinstance(target, str):
             grib_file.close()
-
-
-# Odd utility routines
-def _aslazydata_has_meta():
-    """
-    Work out whether 'iris._lazy_data.as_lazy_data' takes a "meta" kwarg.
-
-    Up to Iris 3.8.0, "as_lazy_data" did not have a 'meta' keyword, but
-    since https://github.com/SciTools/iris/pull/5801, it now *requires* one.
-    """
-    from inspect import signature
-    from iris._lazy_data import as_lazy_data
-
-    sig = signature(as_lazy_data)
-    return "meta" in sig.parameters
-
-
-def _make_dask_meta(shape, dtype, is_masked=True):
-    """
-    Construct a dask 'meta' suitable for 'dask.array.from_array'.
-
-    Result is made from the dtype and shape of an array-like to be mapped,
-    plus whether it will return masked or unmasked arrays.
-    """
-    meta_shape = tuple([0 for _ in shape])
-    array_class = np.ma if is_masked else np
-    meta = array_class.zeros(meta_shape, dtype=dtype)
-    return meta

--- a/src/iris_grib/message.py
+++ b/src/iris_grib/message.py
@@ -167,7 +167,13 @@ class GribMessage:
             else:
                 shape = (grid_section["Nj"], grid_section["Ni"])
             proxy = _DataProxy(shape, np.dtype("f8"), self._recreate_raw)
-            data = as_lazy_data(proxy)
+            # Make a masked/unmasked dask array when there is/not a bitmap
+            #  section
+            has_bitmap = 6 in sections
+            proxy_array_class = np.ma if has_bitmap else np
+            meta_shape = tuple([0 for _ in shape])
+            meta = proxy_array_class.zeros(meta_shape, dtype=proxy.dtype)
+            data = as_lazy_data(proxy, meta=meta)
         else:
             fmt = "Grid definition template {} is not supported"
             raise TranslationError(fmt.format(template))

--- a/src/iris_grib/message.py
+++ b/src/iris_grib/message.py
@@ -171,9 +171,9 @@ class GribMessage:
             proxy = _DataProxy(shape, dtype, self._recreate_raw)
 
             as_lazy_kwargs = {}
-            from . import _aslazydata_has_meta, _make_dask_meta
+            from . import _ASLAZYDATA_NEEDS_META, _make_dask_meta
 
-            if _aslazydata_has_meta():
+            if _ASLAZYDATA_NEEDS_META:
                 has_bitmap = 6 in sections
                 meta = _make_dask_meta(shape, dtype, is_masked=has_bitmap)
                 as_lazy_kwargs["meta"] = meta

--- a/src/iris_grib/tests/unit/test__load_generate.py
+++ b/src/iris_grib/tests/unit/test__load_generate.py
@@ -37,7 +37,7 @@ class Test(tests.IrisGribTest):
                 mock_func.assert_called_once_with(self.fname)
                 self.assertIsInstance(field, GribWrapper)
                 mock_wrapper.assert_called_once_with(
-                    self.message_id, grib_fh=self.grib_fh
+                    self.message_id, grib_fh=self.grib_fh, has_bitmap=False
                 )
 
     def test_grib2(self):


### PR DESCRIPTION
`iris._lazy_data.as_lazy_data` has changed :  See [iris#5801.](https://github.com/SciTools/iris/pull/5801)

Current failing tests against iris latest,
e.g. see https://github.com/SciTools/iris-grib/actions/runs/8892392519/job/24416350591