### PR TITLE
Ensure no warnings on docs build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,6 +19,9 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
+# See https://www.sphinx-doc.org/en/master/man/sphinx-build.html?highlight=--keep-going#cmdoption-sphinx-build-W
+WARNING_TO_ERROR = -W --keep-going
+
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -55,7 +58,7 @@ clean:
 
 .PHONY: html
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) $(WARNING_TO_ERROR) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -303,6 +303,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
+    "python": ("https://docs.python.org/3/", None),
     "iris": ("https://scitools-iris.readthedocs.io/en/stable/", None),
 }

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _release_notes:
 
 Release Notes


### PR DESCRIPTION
Minor updates to the docs:

- Force docs build warnings to be errors 
- Force doc build to continue if there are errors
- Updated an intersphinx mapping
- Added the `:orphan:` tag to the release notes file , else it raises a warning (toctree will now ignore this file)
