### PR TITLE
Support numpy2

### DIFF
--- a/src/iris_grib/_load_convert.py
+++ b/src/iris_grib/_load_convert.py
@@ -213,7 +213,7 @@ class HindcastOverflowWarning(Warning):
 # Non-standardised usage for negative forecast times.
 def _hindcast_fix(forecast_time):
     """Return a forecast time interpreted as a possibly negative value."""
-    uft = np.array(forecast_time).astype(np.uint32)
+    uft = np.array(forecast_time).astype(np.int64)
     HIGHBIT = 2**30
 
     # Workaround grib api's assumption that forecast time is positive.

--- a/src/iris_grib/_load_convert.py
+++ b/src/iris_grib/_load_convert.py
@@ -206,6 +206,10 @@ def unscale(value, factor):
 _MDI = None
 
 
+class HindcastOverflowWarning(Warning):
+    pass
+
+
 # Non-standardised usage for negative forecast times.
 def _hindcast_fix(forecast_time):
     """Return a forecast time interpreted as a possibly negative value."""
@@ -221,7 +225,7 @@ def _hindcast_fix(forecast_time):
             msg = "Re-interpreting large grib forecastTime " "from {} to {}.".format(
                 original_forecast_time, forecast_time
             )
-            warnings.warn(msg)
+            warnings.warn(msg, HindcastOverflowWarning)
 
     return forecast_time
 

--- a/src/iris_grib/tests/unit/load_convert/test__hindcast_fix.py
+++ b/src/iris_grib/tests/unit/load_convert/test__hindcast_fix.py
@@ -8,7 +8,6 @@ Tests for function :func:`iris_grib._load_convert._hindcast_fix`.
 """
 
 from collections import namedtuple
-from unittest import mock
 import warnings
 
 import pytest
@@ -45,10 +44,10 @@ class TestHindcastFix:
 
     def test_fix_warning(self, mocker):
         # Check warning appears when enabled.
-        with mock.patch("iris_grib._load_convert.options.warn_on_unsupported", True):
-            msg = "Re-interpreting large grib forecastTime"
-            with pytest.warns(HindcastOverflowWarning, match=msg):
-                hindcast_fix(2 * 2**30 + 5)
+        mocker.patch("iris_grib._load_convert.options.warn_on_unsupported", True)
+        msg = "Re-interpreting large grib forecastTime"
+        with pytest.warns(HindcastOverflowWarning, match=msg):
+            hindcast_fix(2 * 2**30 + 5)
 
     def test_fix_warning_disabled(self):
         # Default is no warning.


### PR DESCRIPTION
It seems that the only remaining problem for numpy2 is that the update to the code introduced [here in #578](https://github.com/SciTools/iris-grib/pull/578/files#r1866349413) was causing tests to fail, when actually run with numpy 2.

I had meant to keep that issue separate from the eccodes 2v38 one, but somehow I tripped over my own commits.

This PR fixes that, so when merged it should unblock #550 🤞 