### PR TITLE
Full test coverage for GRIB1

### DIFF
--- a/src/iris_grib/tests/integration/load_convert/test_sample_file_loads.py
+++ b/src/iris_grib/tests/integration/load_convert/test_sample_file_loads.py
@@ -117,6 +117,21 @@ class TestBasicLoad(tests.IrisGribTest):
         )
         self.assertCML(cube, _RESULTDIR_PREFIX + ("reduced_gg_grib2.cml",))
 
+    def test_second_order_packing(self):
+        cube = iris.load_cube(
+            tests.get_data_path(
+                ("GRIB", "grib1_second_order_packing", "GRIB_00008_FRANX01")
+            )
+        )
+        self.assertCML(cube, _RESULTDIR_PREFIX + ("second_order_packing.cml",))
+
+    def test_bulletin_headers(self):
+        for byte_len in (40, 41):
+            cube = iris.load_cube(
+                tests.get_data_path(("GRIB", "bulletin", f"{byte_len}bytes.grib"))
+            )
+            self.assertCML(cube, _RESULTDIR_PREFIX + (f"bulletin_{byte_len}bytes.cml",))
+
 
 @tests.skip_data
 class TestIjDirections(tests.IrisGribTest):

--- a/src/iris_grib/tests/results/integration/load_convert/sample_file_loads/bulletin_40bytes.cml
+++ b/src/iris_grib/tests/results/integration/load_convert/sample_file_loads/bulletin_40bytes.cml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" long_name="icao_standard_atmosphere_reference_height" units="m">
+    <attributes>
+      <attribute name="GRIB_PARAM" value="GRIB2:d000c003n003"/>
+    </attributes>
+    <coords>
+      <coord>
+        <dimCoord id="1d45e087" points="[15]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int64"/>
+      </coord>
+      <coord>
+        <dimCoord id="9c8bdf81" points="[367902.]" shape="(1,)" standard_name="forecast_reference_time" units="Unit('hours since 1970-01-01 00:00:00', calendar='standard')" value_type="float64"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="77a50eb5" points="[ 90.  ,  88.75,  87.5 , ..., -87.5 , -88.75,
+ -90.  ]" shape="(145,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord circular="True" id="f913a8b3" points="[  0.  ,   1.25,   2.5 , ..., 356.25, 357.5 ,
+ 358.75]" shape="(288,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6371229.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <dimCoord id="cb784457" points="[367917.]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='standard')" value_type="float64"/>
+      </coord>
+      <coord>
+        <dimCoord id="e2d6f010" points="[0.]" shape="(1,)" units="Unit('unknown')" value_type="float64">
+          <attributes>
+            <attribute name="GRIB_fixed_surface_type" value="11"/>
+          </attributes>
+        </dimCoord>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x47eb69cc" dtype="float64" mask_checksum="0x12cff8b4" shape="(145, 288)"/>
+  </cube>
+</cubes>

--- a/src/iris_grib/tests/results/integration/load_convert/sample_file_loads/bulletin_41bytes.cml
+++ b/src/iris_grib/tests/results/integration/load_convert/sample_file_loads/bulletin_41bytes.cml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" units="unknown">
+    <attributes>
+      <attribute name="GRIB_PARAM" value="GRIB1:t001c085n002"/>
+    </attributes>
+    <coords>
+      <coord>
+        <dimCoord id="1d45e087" points="[72]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="98bcd589" points="[ 45. ,  43.5,  42. ,  40.5,  39. ,  37.5,  36. ,
+  34.5,  33. ,  31.5,  30. ,  28.5,  27. ,  25.5,
+  24. ,  22.5,  21. ,  19.5,  18. ,  16.5,  15. ,
+  13.5,  12. ,  10.5,   9. ,   7.5,   6. ,   4.5,
+   3. ,   1.5,   0. ,  -1.5,  -3. ,  -4.5,  -6. ,
+  -7.5,  -9. , -10.5, -12. , -13.5, -15. , -16.5,
+ -18. , -19.5, -21. , -22.5, -24. , -25.5, -27. ,
+ -28.5, -30. , -31.5, -33. , -34.5, -36. , -37.5,
+ -39. , -40.5, -42. , -43.5, -45. ]" shape="(61,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6367470.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="160a738f" points="[-30. , -28.5, -27. , -25.5, -24. , -22.5, -21. ,
+ -19.5, -18. , -16.5, -15. , -13.5, -12. , -10.5,
+  -9. ,  -7.5,  -6. ,  -4.5,  -3. ,  -1.5,   0. ,
+   1.5,   3. ,   4.5,   6. ,   7.5,   9. ,  10.5,
+  12. ,  13.5,  15. ,  16.5,  18. ,  19.5,  21. ,
+  22.5,  24. ,  25.5,  27. ,  28.5,  30. ,  31.5,
+  33. ,  34.5,  36. ,  37.5,  39. ,  40.5,  42. ,
+  43.5,  45. ,  46.5,  48. ,  49.5,  51. ,  52.5,
+  54. ,  55.5,  57. ,  58.5,  60. ]" shape="(61,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6367470.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="['unknown centre lfpw']" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+      </coord>
+      <coord>
+        <dimCoord id="cb784457" points="[379872.]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='standard')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x6b50c19a" dtype="float64" shape="(61, 61)"/>
+  </cube>
+</cubes>

--- a/src/iris_grib/tests/results/integration/load_convert/sample_file_loads/second_order_packing.cml
+++ b/src/iris_grib/tests/results/integration/load_convert/sample_file_loads/second_order_packing.cml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<cubes xmlns="urn:x-iris:cubeml-0.2">
+  <cube dtype="float64" units="unknown">
+    <attributes>
+      <attribute name="GRIB_PARAM" value="GRIB1:t001c085n008"/>
+    </attributes>
+    <coords>
+      <coord>
+        <dimCoord id="1d45e087" points="[0]" shape="(1,)" standard_name="forecast_period" units="Unit('hours')" value_type="int32"/>
+      </coord>
+      <coord datadims="[0]">
+        <dimCoord id="98bcd589" points="[57. , 56.9, 56.8, ..., 35.2, 35.1, 35. ]" shape="(221,)" standard_name="latitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6367470.0"/>
+        </dimCoord>
+      </coord>
+      <coord datadims="[1]">
+        <dimCoord id="160a738f" points="[-11. , -10.9, -10.8, ...,  16.8,  16.9,  17. ]" shape="(281,)" standard_name="longitude" units="Unit('degrees')" value_type="float64">
+          <geogCS earth_radius="6367470.0"/>
+        </dimCoord>
+      </coord>
+      <coord>
+        <auxCoord id="61bde96d" long_name="originating_centre" points="['unknown centre lfpw']" shape="(1,)" units="Unit('no_unit')" value_type="string"/>
+      </coord>
+      <coord>
+        <dimCoord id="cb784457" points="[-17259552.]" shape="(1,)" standard_name="time" units="Unit('hours since 1970-01-01 00:00:00', calendar='standard')" value_type="float64"/>
+      </coord>
+    </coords>
+    <cellMethods/>
+    <data checksum="0x7c584569" dtype="float64" shape="(221, 281)"/>
+  </cube>
+</cubes>


### PR DESCRIPTION
Closes #488 

We need coverage to be file-based - we can't just mock the `GribWrapper` since we're planning to change to `GribMessage`. Probably can't mock eccodes either given how it manages a file cursor.

The files we have offer _almost_ full coverage of our GRIB1 code (`GribWrapper` and `_grib1_load_rules.py`), but I will need to generate some artificial files (maybe by on-the-fly modification?) to fill the remaining gaps:

- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L446
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L580
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L583
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L587
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L591
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L622
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L628
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L633
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L638
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L647
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L653
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L657
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/__init__.py#L661
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L46
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L143
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L147
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L213
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L224
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L228
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L232
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L236
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L240
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L244
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L248
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L252
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L256
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L260
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L264
- [ ] https://github.com/SciTools/iris-grib/blob/11169cf2f5477c182dd60974c03c5c820244bcc6/src/iris_grib/_grib1_load_rules.py#L299