### PR TITLE
Update to refresh-lockfiles v2025.01.0 

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   refresh_lockfiles:
-    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2024.12.5
+    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2025.01.0
     secrets: inherit


### PR DESCRIPTION
This should resolve to pull in iris 3.11.1, which in turn pins dask to <2024.12, and  fixes the current pickling test problem.
That may only be a temporary fix, but it's in line with the decision for Iris 3.11.1 