### PR TITLE
Release notes for v0.21, to support latest ecCodes.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Iris-grib v0.20
+Iris-grib v0.21
 ===============
 
 The library ``iris-grib`` provides functionality for converting between weather and

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -6,6 +6,31 @@ Release Notes
 =============
 
 
+What's new in iris-grib v0.21.0
+-------------------------------
+
+:Release: 0.21.0
+:Date: 07 January 2025
+
+Dependencies
+^^^^^^^^^^^^
+* `@pp-mo <https://github.com/pp-mo>`_ added a fix to support ecCodes versions >= 2.38
+  `(PR#578) <https://github.com/SciTools/iris-grib/pull/578>`_
+* `@pp-mo <https://github.com/pp-mo>`_ fixed tests to work with numpy versions >= 2.0
+  `(PR#580) <https://github.com/SciTools/iris-grib/pull/580>`_
+
+Internal
+^^^^^^^^
+* `@trexfeathers <https://github.com/trexfeathers>`_ added integration tests to ensure
+  code coverage of GRIB1 loading code, to enable future refactoring.
+  `(ISSUE#488) <https://github.com/SciTools/iris-grib/issues/488>`_,
+  `(PR#583) <https://github.com/SciTools/iris-grib/pull/583>`_
+* `@pp-mo <https://github.com/pp-mo>`_ updated repository automation to current SciTools
+  code quality reccommendations : see https://github.com/orgs/SciTools/projects/43/views/3
+  `(PR#568) <https://github.com/SciTools/iris-grib/pull/568>`_,
+  `(PR#572) <https://github.com/SciTools/iris-grib/pull/572>`_
+
+
 What's new in iris-grib v0.20.0
 -------------------------------
 

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -25,8 +25,8 @@ Internal
   code coverage of GRIB1 loading code, to enable future refactoring.
   `(ISSUE#488) <https://github.com/SciTools/iris-grib/issues/488>`_,
   `(PR#583) <https://github.com/SciTools/iris-grib/pull/583>`_
-* `@pp-mo <https://github.com/pp-mo>`_ updated repository automation to current SciTools
-  code quality reccommendations : see https://github.com/orgs/SciTools/projects/43/views/3
+* `@pp-mo <https://github.com/pp-mo>`_ updated repository automation to meet current
+  SciTools code quality recommendations
   `(PR#568) <https://github.com/SciTools/iris-grib/pull/568>`_,
   `(PR#572) <https://github.com/SciTools/iris-grib/pull/572>`_
 


### PR DESCRIPTION
As usual, we will create a new release branch just in case a bugfix might be needed.
This whatsnew update is the only change not already on main, and after release we'll subsequently merge this back. 

At that point, within the mergeback, we will also change the main documentation page version title to "v0.22 (unreleased)" to avoid confusion.