### PR TITLE
Converted test_pickle_message to pytest, and removed reliance on Iris

### DIFF
--- a/src/iris_grib/tests/unit/message/test_pickle_message.py
+++ b/src/iris_grib/tests/unit/message/test_pickle_message.py
@@ -33,16 +33,16 @@ class TestPickleGribMessage:
         with open(filename, "wb") as f:
             pickle.dump(obj, f, protocol)
         # TODO: resolve this or remove the test.
-        # with open(filename, "rb") as f:
-        #     nobj = pickle.load(f)
-        # assert nobj == obj
+        #  with open(filename, "rb") as f:
+        #      nobj = pickle.load(f)
+        #  assert nobj == obj
 
     @pytest.mark.parametrize("protocol", TESTED_PROTOCOLS)
-    def test_message(self, protocol, messages):
+    def test_message(self, protocol, messages, tmp_path):
         obj = next(messages)
-        self.pickle_obj(obj, protocol)
+        self.pickle_obj(obj, protocol, tmp_path)
 
     @pytest.mark.parametrize("protocol", TESTED_PROTOCOLS)
-    def test_message_data(self, protocol, messages):
+    def test_message_data(self, protocol, messages, tmp_path):
         obj = next(messages).data
-        self.pickle_obj(obj, protocol)
+        self.pickle_obj(obj, protocol, tmp_path)


### PR DESCRIPTION
# Pull Request

Started off as a solution to recent test failures brought on from https://github.com/SciTools/iris/pull/6342, and ended up shuffling the furniture. 

This no longer relies on iris, which hopefully means iris-grib tests won't fail whenever something changes in iris. A couple of things to note:

- Should this still be placed in iris_integration tests? Presumably not.
- I've left in some commented code, which is bad form, but it's essentially a to-do. 
- The tests failing seem to be due to not running on pytest from what I can see, which begs the question, do we abandn this PR, and return to unit test and just fix the immediate failures?