### PR TITLE
pep639: setuptools license and license-files fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [build-system]
 # Defined by PEP 518
 requires = [
-    "setuptools>=64",
+    "setuptools>=77.0.3",
     "setuptools_scm>=8.0",
 ]
 # Defined by PEP 517
@@ -17,7 +17,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",
@@ -46,7 +45,8 @@ keywords = [
     "earth-science",
     "meteorology",
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 name = "iris-grib"
 requires-python = ">=3.10"
 
@@ -55,9 +55,6 @@ Code = "https://github.com/SciTools/iris-grib"
 Discussions = "https://github.com/SciTools/iris-grib/discussions"
 Documentation = "https://iris-grib.readthedocs.io/en/stable/"
 Issues = "https://github.com/SciTools/iris-grib/issues"
-
-[tool.setuptools]
-license-files = ["LICENSE"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements/pypi-core.txt"}

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10
 
 # Setup dependencies.
-  - setuptools>=64
+  - setuptools>=77.0.3
   - setuptools_scm>=8
 
 # Core dependencies.

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.11
 
 # Setup dependencies.
-  - setuptools>=64
+  - setuptools>=77.0.3
   - setuptools_scm>=8
 
 # Core dependencies.

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.12
 
 # Setup dependencies.
-  - setuptools>=64
+  - setuptools>=77.0.3
   - setuptools_scm>=8
 
 # Core dependencies.


### PR DESCRIPTION
This pull-request complies with [PEP639](https://peps.python.org/pep-0639/) for `setuptools`, also see [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

Additionally avoids the following `setuptools` deprecation warning:
```
!!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: BSD License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
!!
```