### PR TITLE
Import and run grib-dependent attribute handling tests from Iris.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,8 +199,6 @@ ignore = [
     "ANN001",
     "ANN002",
     "ANN003",
-    "ANN101",
-    "ANN102",
     "ANN201",
     "ANN202",
     "ANN204",
@@ -387,7 +385,6 @@ ignore = [
     # https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "UP009",
     "UP018",
-    "UP027",
     "UP031",
     "UP032",
     ]

--- a/src/iris_grib/__init__.py
+++ b/src/iris_grib/__init__.py
@@ -4,7 +4,7 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Conversion of cubes to/from GRIB.
 
-See: `ECMWF GRIB API <https://confluence.ecmwf.int/display/MTG2US/Migration+to+Grib+2+-+User+Space+Home>`_.
+See: `ECMWF ecCodes grib interface <https://confluence.ecmwf.int/display/ECC>`_.
 
 """
 

--- a/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
+++ b/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
@@ -1,0 +1,37 @@
+# Copyright iris-grib contributors
+#
+# This file is part of iris-grib and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""
+Integration tests for reading/writing GRIB_PARAM attributes in netcdf files.
+
+N.B. the relevant support code and classes (including testing) are all part of in Iris,
+along with the ones for "STASH" and "ukmo__process_flags" ones.
+
+But all the testing there is optional, and skipped if iris-grib is not installed, so that
+the Iris repo doesn't have to maintain iris-grib as a test dependency.
+
+So, we import + run the relevant tests here instead.
+
+"""
+from iris.tests.integration.netcdf.test_load_managed_attributes import (
+    TestGribParam as LoadGribParamTests
+)
+from iris.tests.integration.netcdf.test_save_managed_attributes import (
+    TestGribParam as SaveGribParamTests
+)
+from iris.tests.unit.fileformats.netcdf.attribute_handlers.test_GribParamHandler import (
+    TestEncodeObject as GribParamHandler_EncodeTests,
+    TestDecodeAttribute as GribParamHandler_DecodeTests
+)
+class TestLoadGribParam_actual(LoadGribParamTests):
+    pass
+
+class TestSaveGribParam_actual(SaveGribParamTests):
+    pass
+
+class TestGribParamHandler_Encode(GribParamHandler_EncodeTests):
+    pass
+
+class TestGribParamHandler_Decode(GribParamHandler_DecodeTests):
+    pass

--- a/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
+++ b/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
@@ -15,6 +15,16 @@ So, we import + run the relevant tests here instead.
 
 """
 
+import pytest
+
+# Start by attempting the key imports from Iris, and skipping all tests if any fail.
+# Needed to run with older Iris (releases) prior to the tests being added.
+# Unfortunately we can't actually use the returned items, as dynamic typing upsets MyPy.
+pytest.importorskip("iris.tests.integration.netcdf.test_load_managed_attributes")
+pytest.importorskip("iris.tests.integration.netcdf.test_save_managed_attributes")
+pytest.importorskip("iris.tests.unit.fileformats.netcdf.attribute_handlers")
+
+
 from iris.tests.integration.netcdf.test_load_managed_attributes import (
     TestGribParam as LoadGribParamTests,
 )
@@ -23,9 +33,8 @@ from iris.tests.integration.netcdf.test_save_managed_attributes import (
     TestGribParam as SaveGribParamTests,
 )
 
-from iris.tests.unit.fileformats.netcdf.attribute_handlers.test_GribParamHandler import (
-    TestEncodeObject as GribParamHandler_EncodeTests,
-    TestDecodeAttribute as GribParamHandler_DecodeTests,
+from iris.tests.unit.fileformats.netcdf.attribute_handlers import (
+    test_GribParamHandler as tgp,
 )
 
 
@@ -37,9 +46,9 @@ class TestSaveGribParam_actual(SaveGribParamTests):
     pass
 
 
-class TestGribParamHandler_Encode(GribParamHandler_EncodeTests):
+class TestGribParamHandler_Encode(tgp.TestEncodeObject):
     pass
 
 
-class TestGribParamHandler_Decode(GribParamHandler_DecodeTests):
+class TestGribParamHandler_Decode(tgp.TestDecodeAttribute):
     pass

--- a/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
+++ b/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
@@ -8,22 +8,27 @@ Integration tests for reading/writing GRIB_PARAM attributes in netcdf files.
 N.B. the relevant support code and classes (including testing) are all part of in Iris,
 along with the ones for "STASH" and "ukmo__process_flags" ones.
 
-But all the testing there is optional, and skipped if iris-grib is not installed, so that
-the Iris repo doesn't have to maintain iris-grib as a test dependency.
+But all the testing there is optional, and skipped if iris-grib is not installed, so
+that the Iris repo doesn't have to maintain iris-grib as a test dependency.
 
 So, we import + run the relevant tests here instead.
 
 """
+
 from iris.tests.integration.netcdf.test_load_managed_attributes import (
     TestGribParam as LoadGribParamTests
 )
+
 from iris.tests.integration.netcdf.test_save_managed_attributes import (
     TestGribParam as SaveGribParamTests
 )
-from iris.tests.unit.fileformats.netcdf.attribute_handlers.test_GribParamHandler import (
-    TestEncodeObject as GribParamHandler_EncodeTests,
-    TestDecodeAttribute as GribParamHandler_DecodeTests
-)
+
+from iris.tests.unit.fileformats.netcdf.attribute_handlers.test_GribParamHandler \
+    import (
+        TestEncodeObject as GribParamHandler_EncodeTests,
+        TestDecodeAttribute as GribParamHandler_DecodeTests
+    )
+
 class TestLoadGribParam_actual(LoadGribParamTests):
     pass
 

--- a/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
+++ b/src/iris_grib/tests/integration/iris_integration/test_nc_attribute_handlers.py
@@ -16,27 +16,30 @@ So, we import + run the relevant tests here instead.
 """
 
 from iris.tests.integration.netcdf.test_load_managed_attributes import (
-    TestGribParam as LoadGribParamTests
+    TestGribParam as LoadGribParamTests,
 )
 
 from iris.tests.integration.netcdf.test_save_managed_attributes import (
-    TestGribParam as SaveGribParamTests
+    TestGribParam as SaveGribParamTests,
 )
 
-from iris.tests.unit.fileformats.netcdf.attribute_handlers.test_GribParamHandler \
-    import (
-        TestEncodeObject as GribParamHandler_EncodeTests,
-        TestDecodeAttribute as GribParamHandler_DecodeTests
-    )
+from iris.tests.unit.fileformats.netcdf.attribute_handlers.test_GribParamHandler import (
+    TestEncodeObject as GribParamHandler_EncodeTests,
+    TestDecodeAttribute as GribParamHandler_DecodeTests,
+)
+
 
 class TestLoadGribParam_actual(LoadGribParamTests):
     pass
 
+
 class TestSaveGribParam_actual(SaveGribParamTests):
     pass
 
+
 class TestGribParamHandler_Encode(GribParamHandler_EncodeTests):
     pass
+
 
 class TestGribParamHandler_Decode(GribParamHandler_DecodeTests):
     pass


### PR DESCRIPTION
N.B. this will not function until https://github.com/SciTools/iris/pull/6566 is merged,
since it uses the new tests provided there.

I think it **_should_** run once that is in, since we test against iris main branch.
Though we do also test against latest-release, and that will still fail until we update this...

### TODO... 
Made into draft as not currently viable...
  * [x] add pytest skips to ensure that tests pass even when the Iris version does not provide the newer tests to import