### PR TITLE
Update broken link.

### DIFF
--- a/src/iris_grib/__init__.py
+++ b/src/iris_grib/__init__.py
@@ -4,7 +4,7 @@
 # See LICENSE in the root of the repository for full licensing details.
 """Conversion of cubes to/from GRIB.
 
-See: `ECMWF GRIB API <https://confluence.ecmwf.int/display/MTG2US/Migration+to+Grib+2+-+User+Space+Home>`_.
+See: `ECMWF ecCodes grib interface <https://confluence.ecmwf.int/display/ECC>`_.
 
 """
 


### PR DESCRIPTION
A number of older ECMWF confluence pages may have been tidied away lately, and we have some similar link breakage on Iris.
But I think this link was out of date anyway.