### PR TITLE
Pre-commit: use `ruff-check` instead of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.13.1"
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         types: [file, python]
         args: [--fix, --show-fixes]
     -   id: ruff-format


### PR DESCRIPTION
Should fix the failures seen across SciTools in the latest pre-commit auto-update, and can be shared via templating.