### PR TITLE
Fix rounding of scaled integers.

### DIFF
--- a/src/iris_grib/_save_rules.py
+++ b/src/iris_grib/_save_rules.py
@@ -219,28 +219,22 @@ def latlon_first_last(x_coord, y_coord, grib):
     if x_coord.has_bounds() or y_coord.has_bounds():
         warnings.warn("Ignoring xy bounds")
 
-    # XXX Pending #1125
-    #    eccodes.codes_set_double(grib, "latitudeOfFirstGridPointInDegrees",
-    #                            float(y_coord.points[0]))
-    #    eccodes.codes_set_double(grib, "latitudeOfLastGridPointInDegrees",
-    #                            float(y_coord.points[-1]))
-    #    eccodes.codes_set_double(grib, "longitudeOfFirstGridPointInDegrees",
-    #                            float(x_coord.points[0]))
-    #    eccodes.codes_set_double(grib, "longitudeOfLastGridPointInDegrees",
-    #                            float(x_coord.points[-1]))
-    # WORKAROUND
-    eccodes.codes_set_long(
-        grib, "latitudeOfFirstGridPoint", int(y_coord.points[0] * 1000000)
-    )
-    eccodes.codes_set_long(
-        grib, "latitudeOfLastGridPoint", int(y_coord.points[-1] * 1000000)
-    )
-    eccodes.codes_set_long(
-        grib, "longitudeOfFirstGridPoint", int((x_coord.points[0] % 360) * 1000000)
-    )
-    eccodes.codes_set_long(
-        grib, "longitudeOfLastGridPoint", int((x_coord.points[-1] % 360) * 1000000)
-    )
+    def scaled_minmax_points(coord):
+        """Get coord scaled min+max values.
+
+        Return numpy integer values, in millionths.
+        Promote values to double-precision before rounding.
+        """
+        float0, float1 = coord.points[[0, -1]]
+        int0, int1 = [int(flt.astype("f8") * 1000000) for flt in (float0, float1)]
+        return int0, int1
+
+    lat0, lat1 = scaled_minmax_points(y_coord)
+    eccodes.codes_set_long(grib, "latitudeOfFirstGridPoint", lat0)
+    eccodes.codes_set_long(grib, "latitudeOfLastGridPoint", lat1)
+    lon0, lon1 = scaled_minmax_points(x_coord)
+    eccodes.codes_set_long(grib, "longitudeOfFirstGridPoint", lon0)
+    eccodes.codes_set_long(grib, "longitudeOfLastGridPoint", lon1)
 
 
 def dx_dy(x_coord, y_coord, grib):

--- a/src/iris_grib/_save_rules.py
+++ b/src/iris_grib/_save_rules.py
@@ -219,20 +219,22 @@ def latlon_first_last(x_coord, y_coord, grib):
     if x_coord.has_bounds() or y_coord.has_bounds():
         warnings.warn("Ignoring xy bounds")
 
-    def scaled_minmax_points(coord):
+    def scaled_minmax_points(coord, wrap_360=False):
         """Get coord scaled min+max values.
 
         Return numpy integer values, in millionths.
         Promote values to double-precision before rounding.
         """
-        float0, float1 = coord.points[[0, -1]]
-        int0, int1 = [int(flt.astype("f8") * 1000000) for flt in (float0, float1)]
+        point0, point1 = coord.points[[0, -1]]
+        if wrap_360:
+            point0, point1 = [point % 360 for point in [point0, point1]]
+        int0, int1 = [int(flt.astype("f8") * 1000000) for flt in (point0, point1)]
         return int0, int1
 
     lat0, lat1 = scaled_minmax_points(y_coord)
     eccodes.codes_set_long(grib, "latitudeOfFirstGridPoint", lat0)
     eccodes.codes_set_long(grib, "latitudeOfLastGridPoint", lat1)
-    lon0, lon1 = scaled_minmax_points(x_coord)
+    lon0, lon1 = scaled_minmax_points(x_coord, wrap_360=True)
     eccodes.codes_set_long(grib, "longitudeOfFirstGridPoint", lon0)
     eccodes.codes_set_long(grib, "longitudeOfLastGridPoint", lon1)
 

--- a/src/iris_grib/tests/unit/save_rules/test_latlon_first_last.py
+++ b/src/iris_grib/tests/unit/save_rules/test_latlon_first_last.py
@@ -1,0 +1,46 @@
+# Copyright iris-grib contributors
+#
+# This file is part of iris-grib and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for `iris_grib.grib_save_rules.identification`."""
+
+import numpy as np
+
+from iris.coords import AuxCoord
+
+from iris_grib._save_rules import latlon_first_last
+
+
+class Test:
+    """Check operation for specific test values.
+
+    The specific point is that coord values should be promoted to "double" to optimise
+    rounding error when converting to integer.
+    In effect, this was the default with numpy 1, but changed in numpy 2.
+    See : https://github.com/SciTools/iris-grib/issues/686
+    """
+
+    # Numbers from a real testcase, where naive non-promoted calculation got it "wrong".
+    lbrow = 1920
+    lbnpt = 2560
+    bzx = -0.070312500000000000000000000000
+    bdx = 0.140625000000000000000000000000
+    bzy = -90.046875000000000000000000000000
+    bdy = 0.093750000000000000000000000000
+
+    def test_lats(self, mocker):
+        patch = mocker.patch("iris_grib._save_rules.eccodes.codes_set_long")
+        x_points = np.array(
+            [self.bzx + self.bdx, self.bzx + self.lbnpt * self.bdx], dtype=np.float32
+        )
+        y_points = np.array(
+            [self.bzy + self.bdy, self.bzy + self.lbrow * self.bdy], dtype=np.float32
+        )
+        x_coord = AuxCoord(x_points)
+        y_coord = AuxCoord(y_points)
+        latlon_first_last(x_coord, y_coord, None)
+        cal = patch.call_args_list
+        assert len(cal) == 4
+        results = [call.args[2] for call in cal]
+        expected = [-89953125, 89953125, 70312, 359929687]
+        assert results == expected

--- a/src/iris_grib/tests/unit/save_rules/test_latlon_first_last.py
+++ b/src/iris_grib/tests/unit/save_rules/test_latlon_first_last.py
@@ -5,6 +5,7 @@
 """Unit tests for `iris_grib.grib_save_rules.identification`."""
 
 import numpy as np
+import pytest
 
 from iris.coords import AuxCoord
 
@@ -28,11 +29,15 @@ class Test:
     bzy = -90.046875000000000000000000000000
     bdy = 0.093750000000000000000000000000
 
-    def test_lats(self, mocker):
+    @pytest.mark.parametrize("wraplons", ["wrapped", "nowrap"])
+    def test_latlons(self, wraplons, mocker):
         patch = mocker.patch("iris_grib._save_rules.eccodes.codes_set_long")
         x_points = np.array(
             [self.bzx + self.bdx, self.bzx + self.lbnpt * self.bdx], dtype=np.float32
         )
+        if wraplons == "wrapped":
+            # Drive longitudes negative : results should be just the same.
+            x_points -= 720
         y_points = np.array(
             [self.bzy + self.bdy, self.bzy + self.lbrow * self.bdy], dtype=np.float32
         )


### PR DESCRIPTION
Closes #686 

NOTE: I've checked that the new test fails with the older code, producing the same values noted in the report :
```
src/iris_grib/tests/unit/save_rules/test_latlon_first_last.py:31 (Test.test_latlons[wrapped])
[-89953128, 89953128, 70312, 359929696] != [-89953125, 89953125, 70312, 359929687]

Expected :[-89953125, 89953125, 70312, 359929687]
Actual   :[-89953128, 89953128, 70312, 359929696]
```