### PR TITLE
Hide not-yet-usable GRIB1 loading controls from public API, and docs.

### DIFF
--- a/src/iris_grib/__init__.py
+++ b/src/iris_grib/__init__.py
@@ -29,8 +29,9 @@ except ModuleNotFoundError:
     __version__ = "unknown"
 
 __all__ = [
-    "GRIB1_LOADING_MODE",
-    "Grib1LoadingMode",
+    # TODO: publish grib1 loading controls, when ready to announce
+    # "GRIB1_LOADING_MODE",
+    # "Grib1LoadingMode",
     "load_cubes",
     "load_pairs_from_fields",
     "save_grib2",


### PR DESCRIPTION
This is an unintended legacy of [Refactor: move grib1 legacy code into its own submodule #738](https://github.com/SciTools/iris-grib/issues/738)

The new `Grib1LoadingMode` (class) and `GRIB1_LOADING_MODE` (context control) are visible in the API docs, but we are **not** ready to go public with this yet
(pending completion of  [Fix GRIB1 support #56](https://github.com/SciTools/iris-grib/issues/56))

Just removing them from the main `__all__` does the trick, I think