### PR TITLE
Update RTD server 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "mambaforge-4.10"
+    python: mambaforge-4.10
   jobs:
     post_checkout:
       # The SciTools/iris-grib repository is shallow i.e., has a .git/shallow,

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-26.04
+  os: ubuntu-24.04
   tools:
     python: "mambaforge-4.10"
   jobs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-26.04
   tools:
-    python: mambaforge-4.10
+    python: "mambaforge-4.10"
   jobs:
     post_checkout:
       # The SciTools/iris-grib repository is shallow i.e., has a .git/shallow,

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-26.04
   tools:
     python: mambaforge-4.10
   jobs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
-    python: mambaforge-4.10
+    python: miniforge3-26.3
   jobs:
     post_checkout:
       # The SciTools/iris-grib repository is shallow i.e., has a .git/shallow,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,7 @@ linkcheck_ignore = [
     "https://github.com/Scitools/iris-grib/compare"
     "/c4243ae..5c314e3#diff-cf46b46880cae59e82a91c7ab6bb81ba"
 ]
+linkcheck_timeout = 60
 
 # -- Autodoc ------------------------------------------------------------------
 


### PR DESCRIPTION
Since RTD is now warning that ubunutu-20 is deprecated.

To highest current ubuntu version = 26.04
_Not_ using 'latest', for stability reasons.