### PR TITLE
V0.23.x

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root ``toctree`` directive.
 
-Iris-grib v0.22
+Iris-grib v0.23
 ===============
 
 The library ``iris-grib`` provides functionality for converting between weather and

--- a/docs/reference/release_notes.rst
+++ b/docs/reference/release_notes.rst
@@ -7,7 +7,9 @@ What's new in iris-grib v0.23.0
 -------------------------------
 
 :Release: 0.23.0
-:Date: TBC
+:Date: 06 March 2026
+
+A small release, adding the ability to save to a reduced-gaussian grid with GDT3.40 .
 
 Features
 ^^^^^^^^


### PR DESCRIPTION
WIP to check versions in re-built docs, only

When release is cut, RTD will build as 'v0.23.0' and 'latest'