### PR TITLE
Set link check timeout to 60

### DIFF
--- a/.github/workflows/ci-linkchecks.yml
+++ b/.github/workflows/ci-linkchecks.yml
@@ -30,6 +30,7 @@ jobs:
           args: |
             --verbose
             --max-concurrency 1
+            --timeout 60
             './docs/**/*.rst'
             './lib/**/*.py'
 


### PR DESCRIPTION
An experiment to see if this can fix ECMWF Confluence timeouts.